### PR TITLE
Add file extension filters to save panels

### DIFF
--- a/src/backend/macos/file_dialog/panel_ffi.rs
+++ b/src/backend/macos/file_dialog/panel_ffi.rs
@@ -160,6 +160,10 @@ impl Panel {
     pub fn build_save_file(opt: &FileDialog) -> Self {
         let panel = Panel::save_panel();
 
+        if !opt.filters.is_empty() {
+            panel.add_filters(&opt);
+        }
+
         if let Some(path) = &opt.starting_directory {
             panel.set_path(path);
         }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -73,6 +73,20 @@ impl FileDialog {
     }
 
     /// Opens save file dialog
+    ///
+    /// #### Platform specific notes regarding save dialog filters:
+    /// - On MacOs
+    ///     - If filter is set, all files will be grayed out (no matter the extension sadly)
+    ///     - If user does not type an extension MacOs will append first available extension from filters list
+    ///     - If user types in filename with extension MacOs will check if it exists in filters list, if not it will display appropriate message
+    /// - On GTK
+    ///     - It only filters which already existing files get shown to the user
+    ///     - It does not append extensions automatically
+    ///     - It does not prevent users from adding any unsupported extension
+    /// - On Win:
+    ///     - If no extension was provided it will just add currently selected one
+    ///     - If selected extension was typed in by the user it will just return
+    ///     - If unselected extension was provided it will append selected one at the end, example: `test.png.txt`
     pub fn save_file(self) -> Option<PathBuf> {
         FileSaveDialogImpl::save_file(self)
     }
@@ -148,6 +162,21 @@ impl AsyncFileDialog {
     /// Opens save file dialog
     ///
     /// Does not exist in `WASM32`
+    ///
+    ///
+    /// #### Platform specific notes regarding save dialog filters:
+    /// - On MacOs
+    ///     - If filter is set, all files will be grayed out (no matter the extension sadly)
+    ///     - If user does not type an extension MacOs will append first available extension from filters list
+    ///     - If user types in filename with extension MacOs will check if it exists in filters list, if not it will display appropriate message
+    /// - On GTK
+    ///     - It only filters which already existing files get shown to the user
+    ///     - It does not append extensions automatically
+    ///     - It does not prevent users from adding any unsupported extension
+    /// - On Win:
+    ///     - If no extension was provided it will just add currently selected one
+    ///     - If selected extension was typed in by the user it will just return
+    ///     - If unselected extension was provided it will append selected one at the end, example: `test.png.txt`
     pub fn save_file(self) -> impl Future<Output = Option<FileHandle>> {
         AsyncFileSaveDialogImpl::save_file_async(self.file_dialog)
     }


### PR DESCRIPTION
Hi there!
First and foremost, thanks A LOT for this library, it helped me working around the winit issue https://github.com/rust-windowing/winit/issues/1779
I am trying to achieve the following: when a user saves a file it is very nice if the dialog itself provides the file extension, reducing the possibility of user error. I investigated how to achieve this under MacOS and found this relevant piece of information:
https://stackoverflow.com/questions/42856370/macos-how-to-have-nssavepanel-to-add-a-file-extension-in-the-file-name

I tried following the suggestion and implemented it in rfd. This very little change was enough to make it work on my MacBook, but I am not familiar with Apple SDKs nor MacOS, so I have no idea if this could somehow break something else.

In the upcoming days I will also investigate if the same can be done under Windows and Linux.