### PR TITLE
Win default file extension

### DIFF
--- a/examples/winit-example/src/main.rs
+++ b/examples/winit-example/src/main.rs
@@ -45,6 +45,27 @@ fn main() {
                 input:
                     event::KeyboardInput {
                         state: event::ElementState::Pressed,
+                        virtual_keycode: Some(winit::event::VirtualKeyCode::S),
+                        ..
+                    },
+                ..
+            } => {
+                let dialog = rfd::AsyncFileDialog::new()
+                    .add_filter("midi", &["mid", "midi"])
+                    .add_filter("rust", &["rs", "toml"])
+                    .set_parent(&window)
+                    .save_file();
+
+                let event_loop_proxy = event_loop_proxy.clone();
+                executor.execut(async move {
+                    let file = dialog.await;
+                    event_loop_proxy.send_event(format!("saved file name: {:#?}", file)).ok();
+                });
+            }
+            WindowEvent::KeyboardInput {
+                input:
+                    event::KeyboardInput {
+                        state: event::ElementState::Pressed,
                         virtual_keycode: Some(winit::event::VirtualKeyCode::F),
                         ..
                     },
@@ -66,10 +87,10 @@ fn main() {
                     event_loop_proxy.send_event(format!("{:#?}", names)).ok();
                 });
             }
-            WindowEvent::DroppedFile(_file_path) => {
+            WindowEvent::DroppedFile(file_path) => {
                 let dialog = rfd::AsyncMessageDialog::new()
-                    .set_title("Msg!")
-                    .set_description("Description!")
+                    .set_title("File dropped")
+                    .set_description(&format!("file path was: {:#?}", file_path))
                     .set_buttons(rfd::MessageButtons::YesNo)
                     .set_parent(&window)
                     .show();

--- a/src/backend/win_cid/file_dialog/dialog_ffi.rs
+++ b/src/backend/win_cid/file_dialog/dialog_ffi.rs
@@ -72,6 +72,15 @@ impl IDialog {
     }
 
     fn add_filters(&self, filters: &[crate::dialog::Filter]) -> Result<(), HRESULT> {
+        if let Some(first_filter) = filters.first() {
+            let extension: Vec<u16> = first_filter.extensions[0].encode_utf16().chain(Some(0)).collect();
+            unsafe {
+                (*self.0)
+                    .SetDefaultExtension(extension.as_ptr())
+                    .check()?;
+            }
+        }
+
         let f_list = {
             let mut f_list = Vec::new();
 

--- a/src/backend/win_cid/file_dialog/dialog_ffi.rs
+++ b/src/backend/win_cid/file_dialog/dialog_ffi.rs
@@ -73,11 +73,13 @@ impl IDialog {
 
     fn add_filters(&self, filters: &[crate::dialog::Filter]) -> Result<(), HRESULT> {
         if let Some(first_filter) = filters.first() {
-            let extension: Vec<u16> = first_filter.extensions[0].encode_utf16().chain(Some(0)).collect();
-            unsafe {
-                (*self.0)
-                    .SetDefaultExtension(extension.as_ptr())
-                    .check()?;
+            if let Some(first_extension) = first_filter.extensions.first() {
+                let extension: Vec<u16> = first_extension.encode_utf16().chain(Some(0)).collect();
+                unsafe {
+                    (*self.0)
+                        .SetDefaultExtension(extension.as_ptr())
+                        .check()?;
+                }
             }
         }
 


### PR DESCRIPTION
While investigating behavior of file dialogs under windows I came upon the https://github.com/ben-wallis/wfd library. In that library the API presents a parameter for the "default extension", and within the source code one can find the following comment:
```
        // Specifies the default extension before the user changes the File Type dropdown. Note that
        // omitting this field will result in no extension ever being appended to a filename that a
        // user types in even after they change the selected File Type.
```
I tested and I can confirm this is what happens in rfd too: setting a file extension in a save dialog under windows does nothing, the returned file name does not have any extension, even if the user clicked on the filter list.
This is the same default behavior as GTK, but in my experience most windows users expect the extension being added automagically, so I think that changing the current behavior might be a good idea.
Side note: currently rfd on MacOS already automatically adds the first provided file filter as an extension, so this pull request would make the behavior of Win and MacOS more similar.