### PR TITLE
Fix misspelling in enum member

### DIFF
--- a/examples/msg.rs
+++ b/examples/msg.rs
@@ -2,7 +2,7 @@ fn main() {
     let res = rfd::MessageDialog::new()
         .set_title("Msg!")
         .set_description("Description!")
-        .set_buttons(rfd::MessageButtons::OkCancle)
+        .set_buttons(rfd::MessageButtons::OkCancel)
         .show();
 
     println!("{}", res);

--- a/src/backend/gtk3/message_dialog.rs
+++ b/src/backend/gtk3/message_dialog.rs
@@ -23,7 +23,7 @@ impl GtkMessageDialog {
 
         let buttons = match opt.buttons {
             MessageButtons::Ok => gtk_sys::GTK_BUTTONS_OK,
-            MessageButtons::OkCancle => gtk_sys::GTK_BUTTONS_OK_CANCEL,
+            MessageButtons::OkCancel => gtk_sys::GTK_BUTTONS_OK_CANCEL,
             MessageButtons::YesNo => gtk_sys::GTK_BUTTONS_YES_NO,
         };
 

--- a/src/backend/macos/message_dialog.rs
+++ b/src/backend/macos/message_dialog.rs
@@ -59,7 +59,7 @@ impl NSAlert {
                 let label = NSString::from_str("OK");
                 let _: () = msg_send![alert, addButtonWithTitle: label];
             },
-            MessageButtons::OkCancle => unsafe {
+            MessageButtons::OkCancel => unsafe {
                 let label = NSString::from_str("OK");
                 let _: () = msg_send![alert, addButtonWithTitle: label];
                 let label = NSString::from_str("Cancel");

--- a/src/backend/wasm.rs
+++ b/src/backend/wasm.rs
@@ -182,7 +182,7 @@ impl MessageDialogImpl for MessageDialog {
                 alert(&text);
                 true
             }
-            MessageButtons::OkCancle | MessageButtons::YesNo => confirm(&text),
+            MessageButtons::OkCancel | MessageButtons::YesNo => confirm(&text),
         }
     }
 }

--- a/src/backend/win_cid/message_dialog.rs
+++ b/src/backend/win_cid/message_dialog.rs
@@ -31,7 +31,7 @@ impl WinMessageDialog {
 
         let buttons = match opt.buttons {
             MessageButtons::Ok => MB_OK,
-            MessageButtons::OkCancle => MB_OKCANCEL,
+            MessageButtons::OkCancel => MB_OKCANCEL,
             MessageButtons::YesNo => MB_YESNO,
         };
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -336,7 +336,7 @@ impl Default for MessageLevel {
 
 pub enum MessageButtons {
     Ok,
-    OkCancle,
+    OkCancel,
     YesNo,
 }
 


### PR DESCRIPTION
I noticed that `MessageButtons`'s `OkCancel` was misspelled as `OkCancle`. This is still very much <1.0.0 so maybe this breaking change is fine.