### PR TITLE
Add set_title to FileDialog

### DIFF
--- a/src/backend/gtk3/file_dialog/dialog_ffi.rs
+++ b/src/backend/gtk3/file_dialog/dialog_ffi.rs
@@ -156,7 +156,7 @@ impl GtkFileDialog {
 impl GtkFileDialog {
     pub fn build_pick_file(opt: &FileDialog) -> Self {
         let mut dialog =
-            GtkFileDialog::new("Open File", GtkFileChooserAction::Open, "Cancel", "Open");
+            GtkFileDialog::new(opt.title.as_deref().unwrap_or("Open File"), GtkFileChooserAction::Open, "Cancel", "Open");
 
         dialog.add_filters(&opt.filters);
         dialog.set_path(opt.starting_directory.as_deref());
@@ -166,7 +166,7 @@ impl GtkFileDialog {
 
     pub fn build_save_file(opt: &FileDialog) -> Self {
         let mut dialog =
-            GtkFileDialog::new("Save File", GtkFileChooserAction::Save, "Cancel", "Save");
+            GtkFileDialog::new(opt.title.as_deref().unwrap_or("Save File"), GtkFileChooserAction::Save, "Cancel", "Save");
 
         unsafe { gtk_sys::gtk_file_chooser_set_do_overwrite_confirmation(dialog.ptr as _, 1) };
 
@@ -194,7 +194,7 @@ impl GtkFileDialog {
 
     pub fn build_pick_folder(opt: &FileDialog) -> Self {
         let dialog = GtkFileDialog::new(
-            "Select Folder",
+            opt.title.as_deref().unwrap_or("Select Folder"),
             GtkFileChooserAction::SelectFolder,
             "Cancel",
             "Select",
@@ -206,7 +206,7 @@ impl GtkFileDialog {
 
     pub fn build_pick_files(opt: &FileDialog) -> Self {
         let mut dialog =
-            GtkFileDialog::new("Open File", GtkFileChooserAction::Open, "Cancel", "Open");
+            GtkFileDialog::new(opt.title.as_deref().unwrap_or("Open File"), GtkFileChooserAction::Open, "Cancel", "Open");
 
         unsafe { gtk_sys::gtk_file_chooser_set_select_multiple(dialog.ptr as _, 1) };
         dialog.add_filters(&opt.filters);

--- a/src/backend/macos/file_dialog/panel_ffi.rs
+++ b/src/backend/macos/file_dialog/panel_ffi.rs
@@ -116,6 +116,13 @@ impl Panel {
         }
     }
 
+    pub fn set_title(&self, title: &str) {
+        unsafe {
+            let title = make_nsstring(title);
+            let () = msg_send![self.panel, setTitle: title];
+        }
+    }
+
     pub fn get_result(&self) -> PathBuf {
         unsafe {
             let url = msg_send![self.panel, URL];
@@ -155,6 +162,10 @@ impl Panel {
             panel.set_file_name(file_name);
         }
 
+        if let Some(title) = &opt.title {
+            panel.set_title(title);
+        }
+
         panel.set_can_choose_directories(NO);
         panel.set_can_choose_files(YES);
 
@@ -176,6 +187,10 @@ impl Panel {
             panel.set_file_name(file_name);
         }
 
+        if let Some(title) = &opt.title {
+            panel.set_title(title);
+        }
+
         panel
     }
 
@@ -184,6 +199,10 @@ impl Panel {
 
         if let Some(path) = &opt.starting_directory {
             panel.set_path(path, opt.file_name.as_deref());
+        }
+
+        if let Some(title) = &opt.title {
+            panel.set_title(title);
         }
 
         panel.set_can_choose_directories(YES);
@@ -201,6 +220,10 @@ impl Panel {
 
         if let Some(path) = &opt.starting_directory {
             panel.set_path(path, opt.file_name.as_deref());
+        }
+
+        if let Some(title) = &opt.title {
+            panel.set_title(title);
         }
 
         panel.set_can_choose_directories(NO);

--- a/src/backend/win_cid/file_dialog/dialog_ffi.rs
+++ b/src/backend/win_cid/file_dialog/dialog_ffi.rs
@@ -174,6 +174,17 @@ impl IDialog {
         Ok(())
     }
 
+    fn set_title(&self, title: &Option<String>) -> Result<(), HRESULT> {
+        if let Some(title) = title {
+            let wide_title: Vec<u16> = OsStr::new(title).encode_wide().chain(once(0)).collect();
+
+            unsafe {
+                (*self.0).SetTitle(wide_title.as_ptr()).check()?;
+            }
+        }
+        Ok(())
+    }
+
     pub fn get_results(&self) -> Result<Vec<PathBuf>, HRESULT> {
         unsafe {
             let mut res_items: *mut IShellItemArray = ptr::null_mut();
@@ -237,6 +248,7 @@ impl IDialog {
         dialog.add_filters(&opt.filters)?;
         dialog.set_path(&opt.starting_directory)?;
         dialog.set_file_name(&opt.file_name)?;
+        dialog.set_title(&opt.title)?;
 
         Ok(dialog)
     }
@@ -247,6 +259,7 @@ impl IDialog {
         dialog.add_filters(&opt.filters)?;
         dialog.set_path(&opt.starting_directory)?;
         dialog.set_file_name(&opt.file_name)?;
+        dialog.set_title(&opt.title)?;
 
         Ok(dialog)
     }
@@ -255,6 +268,7 @@ impl IDialog {
         let dialog = IDialog::new_open_dialog(opt)?;
 
         dialog.set_path(&opt.starting_directory)?;
+        dialog.set_title(&opt.title)?;
 
         unsafe {
             dialog.SetOptions(FOS_PICKFOLDERS).check()?;
@@ -269,6 +283,7 @@ impl IDialog {
         dialog.add_filters(&opt.filters)?;
         dialog.set_path(&opt.starting_directory)?;
         dialog.set_file_name(&opt.file_name)?;
+        dialog.set_title(&opt.title)?;
 
         unsafe {
             dialog.SetOptions(FOS_ALLOWMULTISELECT).check()?;

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -22,6 +22,7 @@ pub struct FileDialog {
     pub(crate) filters: Vec<Filter>,
     pub(crate) starting_directory: Option<PathBuf>,
     pub(crate) file_name: Option<String>,
+    pub(crate) title: Option<String>,
     #[cfg(feature = "parent")]
     pub(crate) parent: Option<RawWindowHandle>,
 }
@@ -70,6 +71,16 @@ impl FileDialog {
     /// - Mac
     pub fn set_file_name(mut self, file_name: &str) -> Self {
         self.file_name = Some(file_name.into());
+        self
+    }
+
+    /// Set the title of the dialog.
+    /// #### Supported Platforms:
+    /// - Windows
+    /// - Linux
+    /// - Mac
+    pub fn set_title(mut self, title: &str) -> Self {
+        self.title = Some(title.into());
         self
     }
 
@@ -169,6 +180,16 @@ impl AsyncFileDialog {
     /// - Mac
     pub fn set_file_name(mut self, file_name: &str) -> Self {
         self.file_dialog = self.file_dialog.set_file_name(file_name);
+        self
+    }
+
+    /// Set the title of the dialog.
+    /// #### Supported Platforms:
+    /// - Windows
+    /// - Linux
+    /// - Mac
+    pub fn set_title(mut self, title: &str) -> Self {
+        self.file_dialog = self.file_dialog.set_title(title);
         self
     }
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -78,7 +78,7 @@ impl FileDialog {
     /// #### Supported Platforms:
     /// - Windows
     /// - Linux
-    /// - Mac
+    /// - Mac (Only below version 10.11)
     pub fn set_title(mut self, title: &str) -> Self {
         self.title = Some(title.into());
         self
@@ -187,7 +187,7 @@ impl AsyncFileDialog {
     /// #### Supported Platforms:
     /// - Windows
     /// - Linux
-    /// - Mac
+    /// - Mac (Only below version 10.11)
     pub fn set_title(mut self, title: &str) -> Self {
         self.file_dialog = self.file_dialog.set_title(title);
         self


### PR DESCRIPTION
I've added a set_title function for windows, linux and mac. Doesn't seem like web-sys supports it (https://stackoverflow.com/questions/19944430/how-to-change-file-upload-dialogs-title-in-a-browser).

Important: I did not test for mac and linux, sorry for the incovenience.