### PR TITLE
Fix duplicate msgbox title on Windows

### DIFF
--- a/src/backend/win_cid/message_dialog.rs
+++ b/src/backend/win_cid/message_dialog.rs
@@ -29,8 +29,7 @@ unsafe impl Send for WinMessageDialog {}
 
 impl WinMessageDialog {
     pub fn new(opt: MessageDialog) -> Self {
-        let input = format!("{}\n{}", opt.title, opt.description);
-        let text: Vec<u16> = OsStr::new(&input).encode_wide().chain(once(0)).collect();
+        let text: Vec<u16> = OsStr::new(&opt.description).encode_wide().chain(once(0)).collect();
         let caption: Vec<u16> = OsStr::new(&opt.title)
             .encode_wide()
             .chain(once(0))


### PR DESCRIPTION
On Windows the title of a message box was shown twice, first in the window title bar (as it should) and then also repeated in the message box window text which is duplicate. This fixes that and only includes the message box title bar on Windows in the window title.

Before:

![image](https://user-images.githubusercontent.com/1262692/135711746-0b852e9a-3003-4477-b0fc-cb4ba5d276fe.png)

Now:

![image](https://user-images.githubusercontent.com/1262692/135711726-f5c01d9e-5696-4aa9-9014-da2723ec4aca.png)
