### PR TITLE
Updated RawWindowHandle dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,11 +411,11 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a441a7a6c80ad6473bd4b74ec1c9a4c951794285bf941c2126f607c72e48211"
+checksum = "503bdbfa9605024fdc97f845002e3690d14c5f553594f1cd0f819317a70de02c"
 dependencies = [
- "libc",
+ "cty",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ name = "simple"
 name = "async"
 
 [dependencies]
-raw-window-handle = { version="0.3.3", optional=true }
+raw-window-handle = { version="0.4.1", optional=true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/backend/macos/utils/window.rs
+++ b/src/backend/macos/utils/window.rs
@@ -11,7 +11,7 @@ pub trait INSWindow: INSObject {
     #[cfg(feature = "parent")]
     fn from_raw_window_handle(h: &RawWindowHandle) -> Id<Self> {
         match h {
-            RawWindowHandle::MacOS(h) => {
+            RawWindowHandle::AppKit(h) => {
                 let id = h.ns_window as *mut Self;
                 unsafe { Id::from_ptr(id) }
             }

--- a/src/backend/win_cid/file_dialog/dialog_ffi.rs
+++ b/src/backend/win_cid/file_dialog/dialog_ffi.rs
@@ -42,7 +42,7 @@ impl IDialog {
 
         #[cfg(feature = "parent")]
         let parent = match opt.parent {
-            Some(RawWindowHandle::Windows(handle)) => Some(HWND(handle.hwnd as isize)),
+            Some(RawWindowHandle::Win32(handle)) => Some(HWND(handle.hwnd as isize)),
             None => None,
             _ => unreachable!("unsupported window handle, expected: Windows"),
         };
@@ -59,7 +59,7 @@ impl IDialog {
 
         #[cfg(feature = "parent")]
         let parent = match opt.parent {
-            Some(RawWindowHandle::Windows(handle)) => Some(HWND(handle.hwnd as isize)),
+            Some(RawWindowHandle::Win32(handle)) => Some(HWND(handle.hwnd as isize)),
             None => None,
             _ => unreachable!("unsupported window handle, expected: Windows"),
         };

--- a/src/backend/win_cid/message_dialog.rs
+++ b/src/backend/win_cid/message_dialog.rs
@@ -50,7 +50,7 @@ impl WinMessageDialog {
 
         #[cfg(feature = "parent")]
         let parent = match opt.parent {
-            Some(RawWindowHandle::Windows(handle)) => Some(HWND(handle.hwnd as isize)),
+            Some(RawWindowHandle::Win32(handle)) => Some(HWND(handle.hwnd as isize)),
             None => None,
             _ => unreachable!("unsupported window handle, expected: Windows"),
         };


### PR DESCRIPTION
Without this change, applications that use a v0.4+ of RawWindowHandle get a build error:

    error[E0277]: the trait bound `Window: raw_window_handle::HasRawWindowHandle` is not satisfied

    help: trait impl with same name found

    note: perhaps two different versions of crate `raw_window_handle` are being used?