### PR TITLE
Strip Win32 namespaces from directory paths

### DIFF
--- a/src/backend/win_cid/file_dialog/dialog_ffi.rs
+++ b/src/backend/win_cid/file_dialog/dialog_ffi.rs
@@ -121,6 +121,9 @@ impl IDialog {
     fn set_path(&self, path: &Option<PathBuf>) -> Result<()> {
         if let Some(path) = path {
             if let Some(path) = path.to_str() {
+                // Strip Win32 namespace prefix from the path
+                let path = path.strip_prefix(r"\\?\").unwrap_or(path);
+
                 let mut wide_path: Vec<u16> =
                     OsStr::new(path).encode_wide().chain(once(0)).collect();
 


### PR DESCRIPTION
- Fixes #32