### PR TITLE
use XDG Desktop Portal on Linux & BSDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ windows = { version = "0.30.0", features = [
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 ashpd = "0.2.0-beta-1"
-smol = "1.2"
+pollster = "0.2"
 log = "0.4"
 gtk-sys = { version = "0.15.1", features = ["v3_20"], optional = true }
 glib-sys = { version = "0.15.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/rfd"
 default = ["parent"]
 parent = ["raw-window-handle"]
 file-handle-inner = []
+gtk3 = ["gtk-sys", "glib-sys", "gobject-sys", "lazy_static"]
 
 [dev-dependencies]
 futures = "0.3.12"
@@ -35,11 +36,14 @@ windows = { version = "0.30.0", features = [
   "Win32_UI_WindowsAndMessaging",
 ] }
 
-[target.'cfg(any(target_os = "freebsd", target_os = "linux"))'.dependencies]
-gtk-sys = { version = "0.15.1", features = ["v3_20"] }
-glib-sys = "0.15.1"
-gobject-sys = "0.15.1"
-lazy_static = "1.4.0"
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
+ashpd = "0.2.0-beta-1"
+smol = "1.2"
+log = "0.4"
+gtk-sys = { version = "0.15.1", features = ["v3_20"], optional = true }
+glib-sys = { version = "0.15.1", optional = true }
+gobject-sys = { version = "0.15.1", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/PolyMeilex/rfd"
 documentation = "https://docs.rs/rfd"
 
 [features]
-default = ["parent"]
+default = ["parent", "gtk3"]
 parent = ["raw-window-handle"]
 file-handle-inner = []
 gtk3 = ["gtk-sys", "glib-sys", "gobject-sys", "lazy_static"]

--- a/examples/msg.rs
+++ b/examples/msg.rs
@@ -1,4 +1,19 @@
 fn main() {
+    let res = "";
+    #[cfg(any(
+        target_os = "windows",
+        target_os = "macos",
+        all(
+            any(
+                target_os = "linux",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ),
+            feature = "gtk3"
+        )
+    ))]
     let res = rfd::MessageDialog::new()
         .set_title("Msg!")
         .set_description("Description!")

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3,7 +3,16 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 
-#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+#[cfg(all(
+    any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ),
+    feature = "gtk3"
+))]
 mod gtk3;
 #[cfg(target_os = "macos")]
 mod macos;
@@ -11,6 +20,17 @@ mod macos;
 mod wasm;
 #[cfg(target_os = "windows")]
 mod win_cid;
+#[cfg(all(
+    any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ),
+    not(feature = "gtk3")
+))]
+mod xdg_desktop_portal;
 
 //
 // Sync

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -8,6 +8,7 @@ use ashpd::desktop::file_chooser::{
     FileChooserProxy, FileFilter, OpenFileOptions, SaveFileOptions,
 };
 // TODO: convert raw_window_handle::RawWindowHandle to ashpd::WindowIdentifier
+// https://github.com/bilelmoussaoui/ashpd/issues/40
 use ashpd::{zbus, WindowIdentifier};
 
 use log::warn;

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -1,0 +1,284 @@
+use std::path::PathBuf;
+
+use crate::backend::DialogFutureType;
+use crate::file_dialog::Filter;
+use crate::{FileDialog, FileHandle};
+
+use ashpd::desktop::file_chooser::{
+    FileChooserProxy, FileFilter, OpenFileOptions, SaveFileOptions,
+};
+// TODO: convert raw_window_handle::RawWindowHandle to ashpd::WindowIdentifier
+use ashpd::{zbus, WindowIdentifier};
+
+use log::warn;
+use smol::block_on;
+
+//
+// Utility functions
+//
+
+fn add_filters_to_open_file_options(
+    filters: Vec<Filter>,
+    mut options: OpenFileOptions,
+) -> OpenFileOptions {
+    for filter in &filters {
+        let mut ashpd_filter = FileFilter::new(&filter.name);
+        for file_extension in &filter.extensions {
+            ashpd_filter = ashpd_filter.glob(&format!("*.{}", file_extension));
+        }
+        options = options.add_filter(ashpd_filter);
+    }
+    options
+}
+
+fn add_filters_to_save_file_options(
+    filters: Vec<Filter>,
+    mut options: SaveFileOptions,
+) -> SaveFileOptions {
+    for filter in &filters {
+        let mut ashpd_filter = FileFilter::new(&filter.name);
+        for file_extension in &filter.extensions {
+            ashpd_filter = ashpd_filter.glob(&format!("*.{}", file_extension));
+        }
+        options = options.add_filter(ashpd_filter);
+    }
+    options
+}
+
+// refer to https://github.com/flatpak/xdg-desktop-portal/issues/213
+fn uri_to_pathbuf(uri: &str) -> Option<PathBuf> {
+    uri.strip_prefix("file://").map(PathBuf::from)
+}
+
+fn unwrap_or_warn<T, E: std::fmt::Debug>(result: Result<T, E>) -> Option<T> {
+    match result {
+        Err(e) => {
+            warn!("{:?}", e);
+            None
+        }
+        Ok(t) => Some(t),
+    }
+}
+
+//
+// File Picker
+//
+
+use crate::backend::FilePickerDialogImpl;
+impl FilePickerDialogImpl for FileDialog {
+    fn pick_file(self) -> Option<PathBuf> {
+        let connection = unwrap_or_warn(block_on(zbus::Connection::session()))?;
+        let proxy = unwrap_or_warn(block_on(FileChooserProxy::new(&connection)))?;
+        let mut options = OpenFileOptions::default()
+            .accept_label("Pick file")
+            .multiple(false);
+        options = add_filters_to_open_file_options(self.filters, options);
+        let selected_files = block_on(proxy.open_file(
+            &WindowIdentifier::default(),
+            &self.title.unwrap_or_else(|| "Pick a file".to_string()),
+            options,
+        ));
+        if selected_files.is_err() {
+            return None;
+        }
+        uri_to_pathbuf(&selected_files.unwrap().uris()[0])
+    }
+
+    fn pick_files(self) -> Option<Vec<PathBuf>> {
+        let connection = unwrap_or_warn(block_on(zbus::Connection::session()))?;
+        let proxy = unwrap_or_warn(block_on(FileChooserProxy::new(&connection)))?;
+        let mut options = OpenFileOptions::default()
+            .accept_label("Pick file")
+            .multiple(true);
+        options = add_filters_to_open_file_options(self.filters, options);
+        let selected_files = block_on(proxy.open_file(
+            &WindowIdentifier::default(),
+            &self.title.unwrap_or_else(|| "Pick a file".to_string()),
+            options,
+        ));
+        if selected_files.is_err() {
+            return None;
+        }
+        let selected_files = selected_files
+            .unwrap()
+            .uris()
+            .iter()
+            .filter_map(|string| uri_to_pathbuf(string))
+            .collect::<Vec<PathBuf>>();
+        if selected_files.is_empty() {
+            return None;
+        }
+        Some(selected_files)
+    }
+}
+
+use crate::backend::AsyncFilePickerDialogImpl;
+impl AsyncFilePickerDialogImpl for FileDialog {
+    fn pick_file_async(self) -> DialogFutureType<Option<FileHandle>> {
+        Box::pin(async {
+            let connection = unwrap_or_warn(zbus::Connection::session().await)?;
+            let proxy = unwrap_or_warn(FileChooserProxy::new(&connection).await)?;
+            let mut options = OpenFileOptions::default()
+                .accept_label("Pick file")
+                .multiple(false);
+            options = add_filters_to_open_file_options(self.filters, options);
+            let selected_files = proxy
+                .open_file(
+                    &WindowIdentifier::default(),
+                    &self.title.unwrap_or_else(|| "Pick a file".to_string()),
+                    options,
+                )
+                .await;
+            if selected_files.is_err() {
+                return None;
+            }
+            uri_to_pathbuf(&selected_files.unwrap().uris()[0]).map(FileHandle::from)
+        })
+    }
+
+    fn pick_files_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
+        Box::pin(async {
+            let connection = unwrap_or_warn(zbus::Connection::session().await)?;
+            let proxy = unwrap_or_warn(FileChooserProxy::new(&connection).await)?;
+            let mut options = OpenFileOptions::default()
+                .accept_label("Pick file(s)")
+                .multiple(true);
+            options = add_filters_to_open_file_options(self.filters, options);
+            let selected_files = proxy
+                .open_file(
+                    &WindowIdentifier::default(),
+                    &self
+                        .title
+                        .unwrap_or_else(|| "Pick one or more files".to_string()),
+                    options,
+                )
+                .await;
+            if selected_files.is_err() {
+                return None;
+            }
+            let selected_files = selected_files
+                .unwrap()
+                .uris()
+                .iter()
+                .filter_map(|string| uri_to_pathbuf(string))
+                .map(FileHandle::from)
+                .collect::<Vec<FileHandle>>();
+            if selected_files.is_empty() {
+                return None;
+            }
+            Some(selected_files)
+        })
+    }
+}
+
+//
+// Folder Picker
+//
+
+use crate::backend::FolderPickerDialogImpl;
+impl FolderPickerDialogImpl for FileDialog {
+    fn pick_folder(self) -> Option<PathBuf> {
+        let connection = unwrap_or_warn(block_on(zbus::Connection::session()))?;
+        let proxy = unwrap_or_warn(block_on(FileChooserProxy::new(&connection)))?;
+        let mut options = OpenFileOptions::default()
+            .accept_label("Pick folder")
+            .multiple(false)
+            .directory(true);
+        options = add_filters_to_open_file_options(self.filters, options);
+        let selected_files = block_on(proxy.open_file(
+            &WindowIdentifier::default(),
+            &self.title.unwrap_or_else(|| "Pick a folder".to_string()),
+            options,
+        ));
+        if selected_files.is_err() {
+            return None;
+        }
+        uri_to_pathbuf(&selected_files.unwrap().uris()[0])
+    }
+}
+
+use crate::backend::AsyncFolderPickerDialogImpl;
+impl AsyncFolderPickerDialogImpl for FileDialog {
+    fn pick_folder_async(self) -> DialogFutureType<Option<FileHandle>> {
+        Box::pin(async {
+            let connection = zbus::Connection::session().await.ok()?;
+            let proxy = FileChooserProxy::new(&connection).await.ok()?;
+            let mut options = OpenFileOptions::default()
+                .accept_label("Pick folder")
+                .multiple(false)
+                .directory(true);
+            options = add_filters_to_open_file_options(self.filters, options);
+            let selected_files = proxy
+                .open_file(
+                    &WindowIdentifier::default(),
+                    &self.title.unwrap_or_else(|| "Pick a folder".to_string()),
+                    options,
+                )
+                .await;
+            if selected_files.is_err() {
+                return None;
+            }
+            uri_to_pathbuf(&selected_files.unwrap().uris()[0]).map(FileHandle::from)
+        })
+    }
+}
+
+//
+// File Save
+//
+
+use crate::backend::FileSaveDialogImpl;
+impl FileSaveDialogImpl for FileDialog {
+    fn save_file(self) -> Option<PathBuf> {
+        let connection = block_on(zbus::Connection::session()).ok()?;
+        let proxy = block_on(FileChooserProxy::new(&connection)).ok()?;
+        let mut options = SaveFileOptions::default().accept_label("Save");
+        options = add_filters_to_save_file_options(self.filters, options);
+        if let Some(file_name) = self.file_name {
+            options = options.current_name(&file_name);
+        }
+        // TODO: impl zvariant::Type for PathBuf?
+        // if let Some(dir) = self.starting_directory {
+        //    options.current_folder(dir);
+        // }
+        let selected_files = block_on(proxy.save_file(
+            &WindowIdentifier::default(),
+            &self.title.unwrap_or_else(|| "Save file".to_string()),
+            options,
+        ));
+        if selected_files.is_err() {
+            return None;
+        }
+        uri_to_pathbuf(&selected_files.unwrap().uris()[0])
+    }
+}
+
+use crate::backend::AsyncFileSaveDialogImpl;
+impl AsyncFileSaveDialogImpl for FileDialog {
+    fn save_file_async(self) -> DialogFutureType<Option<FileHandle>> {
+        Box::pin(async {
+            let connection = zbus::Connection::session().await.ok()?;
+            let proxy = FileChooserProxy::new(&connection).await.ok()?;
+            let mut options = SaveFileOptions::default().accept_label("Save");
+            options = add_filters_to_save_file_options(self.filters, options);
+            if let Some(file_name) = self.file_name {
+                options = options.current_name(&file_name);
+            }
+            // TODO: impl zvariant::Type for PathBuf?
+            // if let Some(dir) = self.starting_directory {
+            //    options.current_folder(dir);
+            // }
+            let selected_files = proxy
+                .save_file(
+                    &WindowIdentifier::default(),
+                    &self.title.unwrap_or_else(|| "Save file".to_string()),
+                    options,
+                )
+                .await;
+            if selected_files.is_err() {
+                return None;
+            }
+            uri_to_pathbuf(&selected_files.unwrap().uris()[0]).map(FileHandle::from)
+        })
+    }
+}

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -50,7 +50,7 @@ fn uri_to_pathbuf(uri: &str) -> Option<PathBuf> {
     uri.strip_prefix("file://").map(PathBuf::from)
 }
 
-fn unwrap_or_warn<T, E: std::fmt::Debug>(result: Result<T, E>) -> Option<T> {
+fn ok_or_warn<T, E: std::fmt::Debug>(result: Result<T, E>) -> Option<T> {
     match result {
         Err(e) => {
             warn!("{:?}", e);
@@ -67,8 +67,8 @@ fn unwrap_or_warn<T, E: std::fmt::Debug>(result: Result<T, E>) -> Option<T> {
 use crate::backend::FilePickerDialogImpl;
 impl FilePickerDialogImpl for FileDialog {
     fn pick_file(self) -> Option<PathBuf> {
-        let connection = unwrap_or_warn(block_on(zbus::Connection::session()))?;
-        let proxy = unwrap_or_warn(block_on(FileChooserProxy::new(&connection)))?;
+        let connection = ok_or_warn(block_on(zbus::Connection::session()))?;
+        let proxy = ok_or_warn(block_on(FileChooserProxy::new(&connection)))?;
         let mut options = OpenFileOptions::default()
             .accept_label("Pick file")
             .multiple(false);
@@ -85,8 +85,8 @@ impl FilePickerDialogImpl for FileDialog {
     }
 
     fn pick_files(self) -> Option<Vec<PathBuf>> {
-        let connection = unwrap_or_warn(block_on(zbus::Connection::session()))?;
-        let proxy = unwrap_or_warn(block_on(FileChooserProxy::new(&connection)))?;
+        let connection = ok_or_warn(block_on(zbus::Connection::session()))?;
+        let proxy = ok_or_warn(block_on(FileChooserProxy::new(&connection)))?;
         let mut options = OpenFileOptions::default()
             .accept_label("Pick file")
             .multiple(true);
@@ -116,8 +116,8 @@ use crate::backend::AsyncFilePickerDialogImpl;
 impl AsyncFilePickerDialogImpl for FileDialog {
     fn pick_file_async(self) -> DialogFutureType<Option<FileHandle>> {
         Box::pin(async {
-            let connection = unwrap_or_warn(zbus::Connection::session().await)?;
-            let proxy = unwrap_or_warn(FileChooserProxy::new(&connection).await)?;
+            let connection = ok_or_warn(zbus::Connection::session().await)?;
+            let proxy = ok_or_warn(FileChooserProxy::new(&connection).await)?;
             let mut options = OpenFileOptions::default()
                 .accept_label("Pick file")
                 .multiple(false);
@@ -138,8 +138,8 @@ impl AsyncFilePickerDialogImpl for FileDialog {
 
     fn pick_files_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
         Box::pin(async {
-            let connection = unwrap_or_warn(zbus::Connection::session().await)?;
-            let proxy = unwrap_or_warn(FileChooserProxy::new(&connection).await)?;
+            let connection = ok_or_warn(zbus::Connection::session().await)?;
+            let proxy = ok_or_warn(FileChooserProxy::new(&connection).await)?;
             let mut options = OpenFileOptions::default()
                 .accept_label("Pick file(s)")
                 .multiple(true);
@@ -178,8 +178,8 @@ impl AsyncFilePickerDialogImpl for FileDialog {
 use crate::backend::FolderPickerDialogImpl;
 impl FolderPickerDialogImpl for FileDialog {
     fn pick_folder(self) -> Option<PathBuf> {
-        let connection = unwrap_or_warn(block_on(zbus::Connection::session()))?;
-        let proxy = unwrap_or_warn(block_on(FileChooserProxy::new(&connection)))?;
+        let connection = ok_or_warn(block_on(zbus::Connection::session()))?;
+        let proxy = ok_or_warn(block_on(FileChooserProxy::new(&connection)))?;
         let mut options = OpenFileOptions::default()
             .accept_label("Pick folder")
             .multiple(false)

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -11,7 +11,7 @@ use ashpd::desktop::file_chooser::{
 use ashpd::{zbus, WindowIdentifier};
 
 use log::warn;
-use smol::block_on;
+use pollster::block_on;
 
 //
 // Utility functions

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -157,8 +157,8 @@ use crate::backend::AsyncFolderPickerDialogImpl;
 impl AsyncFolderPickerDialogImpl for FileDialog {
     fn pick_folder_async(self) -> DialogFutureType<Option<FileHandle>> {
         Box::pin(async {
-            let connection = zbus::Connection::session().await.ok()?;
-            let proxy = FileChooserProxy::new(&connection).await.ok()?;
+            let connection = ok_or_warn(zbus::Connection::session().await)?;
+            let proxy = ok_or_warn(FileChooserProxy::new(&connection).await)?;
             let mut options = OpenFileOptions::default()
                 .accept_label("Pick folder")
                 .multiple(false)
@@ -195,8 +195,8 @@ use crate::backend::AsyncFileSaveDialogImpl;
 impl AsyncFileSaveDialogImpl for FileDialog {
     fn save_file_async(self) -> DialogFutureType<Option<FileHandle>> {
         Box::pin(async {
-            let connection = zbus::Connection::session().await.ok()?;
-            let proxy = FileChooserProxy::new(&connection).await.ok()?;
+            let connection = ok_or_warn(zbus::Connection::session().await)?;
+            let proxy = ok_or_warn(FileChooserProxy::new(&connection).await)?;
             let mut options = SaveFileOptions::default().accept_label("Save");
             options = add_filters_to_save_file_options(self.filters, options);
             if let Some(file_name) = self.file_name {

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -60,6 +60,11 @@ fn ok_or_warn<T, E: std::fmt::Debug>(result: Result<T, E>) -> Option<T> {
     }
 }
 
+async fn file_chooser_proxy<'a>() -> Option<FileChooserProxy<'a>> {
+    let connection = ok_or_warn(zbus::Connection::session().await)?;
+    ok_or_warn(FileChooserProxy::new(&connection).await)
+}
+
 //
 // File Picker
 //
@@ -80,8 +85,7 @@ use crate::backend::AsyncFilePickerDialogImpl;
 impl AsyncFilePickerDialogImpl for FileDialog {
     fn pick_file_async(self) -> DialogFutureType<Option<FileHandle>> {
         Box::pin(async {
-            let connection = ok_or_warn(zbus::Connection::session().await)?;
-            let proxy = ok_or_warn(FileChooserProxy::new(&connection).await)?;
+            let proxy = file_chooser_proxy().await?;
             let mut options = OpenFileOptions::default()
                 .accept_label("Pick file")
                 .multiple(false);
@@ -102,8 +106,7 @@ impl AsyncFilePickerDialogImpl for FileDialog {
 
     fn pick_files_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
         Box::pin(async {
-            let connection = ok_or_warn(zbus::Connection::session().await)?;
-            let proxy = ok_or_warn(FileChooserProxy::new(&connection).await)?;
+            let proxy = file_chooser_proxy().await?;
             let mut options = OpenFileOptions::default()
                 .accept_label("Pick file(s)")
                 .multiple(true);
@@ -150,8 +153,7 @@ use crate::backend::AsyncFolderPickerDialogImpl;
 impl AsyncFolderPickerDialogImpl for FileDialog {
     fn pick_folder_async(self) -> DialogFutureType<Option<FileHandle>> {
         Box::pin(async {
-            let connection = ok_or_warn(zbus::Connection::session().await)?;
-            let proxy = ok_or_warn(FileChooserProxy::new(&connection).await)?;
+            let proxy = file_chooser_proxy().await?;
             let mut options = OpenFileOptions::default()
                 .accept_label("Pick folder")
                 .multiple(false)
@@ -187,8 +189,7 @@ use crate::backend::AsyncFileSaveDialogImpl;
 impl AsyncFileSaveDialogImpl for FileDialog {
     fn save_file_async(self) -> DialogFutureType<Option<FileHandle>> {
         Box::pin(async {
-            let connection = ok_or_warn(zbus::Connection::session().await)?;
-            let proxy = ok_or_warn(FileChooserProxy::new(&connection).await)?;
+            let proxy = file_chooser_proxy().await?;
             let mut options = SaveFileOptions::default().accept_label("Save");
             options = add_filters_to_save_file_options(self.filters, options);
             if let Some(file_name) = self.file_name {

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -67,18 +67,12 @@ fn ok_or_warn<T, E: std::fmt::Debug>(result: Result<T, E>) -> Option<T> {
 use crate::backend::FilePickerDialogImpl;
 impl FilePickerDialogImpl for FileDialog {
     fn pick_file(self) -> Option<PathBuf> {
-        block_on(self.pick_file_async())
-            .map(PathBuf::from)
+        block_on(self.pick_file_async()).map(PathBuf::from)
     }
 
     fn pick_files(self) -> Option<Vec<PathBuf>> {
         block_on(self.pick_files_async())
-            .map(|vec_file_handle| {
-                vec_file_handle
-                .iter()
-                .map(PathBuf::from)
-                .collect()
-            })
+            .map(|vec_file_handle| vec_file_handle.iter().map(PathBuf::from).collect())
     }
 }
 
@@ -148,8 +142,7 @@ impl AsyncFilePickerDialogImpl for FileDialog {
 use crate::backend::FolderPickerDialogImpl;
 impl FolderPickerDialogImpl for FileDialog {
     fn pick_folder(self) -> Option<PathBuf> {
-        block_on(self.pick_folder_async())
-            .map(PathBuf::from)
+        block_on(self.pick_folder_async()).map(PathBuf::from)
     }
 }
 
@@ -186,8 +179,7 @@ impl AsyncFolderPickerDialogImpl for FileDialog {
 use crate::backend::FileSaveDialogImpl;
 impl FileSaveDialogImpl for FileDialog {
     fn save_file(self) -> Option<PathBuf> {
-        block_on(self.save_file_async())
-            .map(PathBuf::from)
+        block_on(self.save_file_async()).map(PathBuf::from)
     }
 }
 

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -68,7 +68,7 @@ use crate::backend::FilePickerDialogImpl;
 impl FilePickerDialogImpl for FileDialog {
     fn pick_file(self) -> Option<PathBuf> {
         block_on(self.pick_file_async())
-            .map(|file_handle| PathBuf::from(file_handle.path()))
+            .map(PathBuf::from)
     }
 
     fn pick_files(self) -> Option<Vec<PathBuf>> {
@@ -76,7 +76,7 @@ impl FilePickerDialogImpl for FileDialog {
             .map(|vec_file_handle| {
                 vec_file_handle
                 .iter()
-                .map(|file_handle| PathBuf::from(file_handle.path()))
+                .map(PathBuf::from)
                 .collect()
             })
     }
@@ -149,7 +149,7 @@ use crate::backend::FolderPickerDialogImpl;
 impl FolderPickerDialogImpl for FileDialog {
     fn pick_folder(self) -> Option<PathBuf> {
         block_on(self.pick_folder_async())
-            .map(|file_handle| PathBuf::from(file_handle.path()))
+            .map(PathBuf::from)
     }
 }
 
@@ -187,7 +187,7 @@ use crate::backend::FileSaveDialogImpl;
 impl FileSaveDialogImpl for FileDialog {
     fn save_file(self) -> Option<PathBuf> {
         block_on(self.save_file_async())
-            .map(|file_handle| PathBuf::from(file_handle.path()))
+            .map(PathBuf::from)
     }
 }
 

--- a/src/file_handle/native.rs
+++ b/src/file_handle/native.rs
@@ -119,3 +119,15 @@ impl From<PathBuf> for FileHandle {
         Self(path)
     }
 }
+
+impl From<FileHandle> for PathBuf {
+    fn from(file_handle: FileHandle) -> Self {
+        PathBuf::from(file_handle.path())
+    }
+}
+
+impl From<&FileHandle> for PathBuf {
+    fn from(file_handle: &FileHandle) -> Self {
+        PathBuf::from(file_handle.path())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,36 @@ pub use file_dialog::FileDialog;
 
 pub use file_dialog::AsyncFileDialog;
 
+#[cfg(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_family = "wasm",
+    all(
+        any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ),
+        feature = "gtk3"
+    )
+))]
 mod message_dialog;
 
+#[cfg(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_family = "wasm",
+    all(
+        any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ),
+        feature = "gtk3"
+    )
+))]
 pub use message_dialog::{AsyncMessageDialog, MessageButtons, MessageDialog, MessageLevel};


### PR DESCRIPTION
This new backend does not support MessageDialog nor
AsyncMessageDialog because there is no corresponding API in the
XDG Desktop Portal.

The GTK backend is still available with the new `gtk3` Cargo
feature.

Fixes #36