### PR TITLE
Bump windows to 0.32.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ block = "0.1.6"
 objc-foundation = "0.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.30.0", features = [
+windows = { version = "0.32.0", features = [
   "Win32_Foundation",
   "Win32_System_Com",
   "Win32_UI_Shell_Common",


### PR DESCRIPTION
The `windows` 0.30 version being used has an [unsound advisory](https://rustsec.org/advisories/RUSTSEC-2022-0008), this just bumps the `windows` version to fix that issue.