### PR TITLE
Fix Windows link error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ windows = { version = "0.32.0", features = [
   "Win32_UI_Shell_Common",
   "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging",
+  "Win32_System_Ole",
 ] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ windows = { version = "0.32.0", features = [
   "Win32_UI_Shell_Common",
   "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging",
-  "Win32_System_Ole",
 ] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ block = "0.1.6"
 objc-foundation = "0.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.30.0", features = [
+windows = { version = "0.32.0", features = [
   "Win32_Foundation",
   "Win32_System_Com",
   "Win32_UI_Shell_Common",

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,10 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=AppKit");
     }
 
+    if target.contains("windows") {
+        println!("cargo:rustc-link-lib=dylib=oleaut32");
+    }
+
     #[cfg(all(feature = "gtk3", feature = "xdg-portal"))]
     compile_error!("You can't enable both GTK3 & XDG Portal features at once");
 

--- a/build.rs
+++ b/build.rs
@@ -10,4 +10,8 @@ fn main() {
 
     #[cfg(not(any(feature = "gtk3", feature = "xdg-portal")))]
     compile_error!("You need to choose at least one backend: `gtk3` or `xdg-portal` features");
+
+    if target.contains("windows") {
+        println!("cargo:rustc-link-lib=static=oleaut32");
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -10,8 +10,4 @@ fn main() {
 
     #[cfg(not(any(feature = "gtk3", feature = "xdg-portal")))]
     compile_error!("You need to choose at least one backend: `gtk3` or `xdg-portal` features");
-
-    if target.contains("windows") {
-        println!("cargo:rustc-link-lib=static=oleaut32");
-    }
 }


### PR DESCRIPTION
When linking with this new Windows version, we were getting multiple link errors due to missing symbols all from oleaut32.lib, which wasn't being added as a link library. This forces linking this, but I think the proper fix will be in the windows crate, I just wanted to add this here so that anyone who updates to a new rfd version doesn't get the linker errors.

Example output:

```
[2022-02-14T15:33:37Z]           lld-link: error: undefined symbol: __declspec(dllimport) SysStringLen
--


[2022-02-14T15:33:37Z]
           &gt;&gt;&gt;               
libwindows-d346ead19c287673.rlib(windows-d346ead19c287673.windows.0beadc8f-cgu.14.rcgu.o):(_$LT$windows..core..error..Error$u20$as$u20$core..convert..From$LT$windows..core..hresult..HRESULT$GT$$GT$::from::h68a2a2662d30f528)
```