### PR TITLE
Bump ashpd to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ windows = { version = "0.33", features = [
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 # XDG Desktop Portal
-ashpd = { version = "0.2", optional = true }
+ashpd = { version = "0.3", optional = true }
 pollster = { version = "0.2", optional = true }
 # GTK
 gtk-sys = { version = "0.15.1", features = ["v3_20"], optional = true }


### PR DESCRIPTION
It should be nowadays possible to create a WindowIdentifier from raw-handle, in case someone wants to do that