### PR TITLE
Add a note to install libgtk before compiling on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,20 @@ It provides both asynchronous and synchronous APIs. Supported platforms:
   * WASM32 (async only)
 
 Refer to the [documentation](https://docs.rs/rfd) for more details.
+
+
+## Platform-specific notes
+
+### Linux
+Gtk and its related libraries are used to build the support of Linux. Be sure to install following packages before building:
+
+### Arch Linux / Manjaro:
+
+```sh
+sudo pacman -S gtk3
+```
+
+### Debian / Ubuntu:
+```sh
+sudo apt install libgtk-3-dev
+```

--- a/README.md
+++ b/README.md
@@ -18,15 +18,4 @@ Refer to the [documentation](https://docs.rs/rfd) for more details.
 ## Platform-specific notes
 
 ### Linux
-Gtk and its related libraries are used to build the support of Linux. Be sure to install following packages before building:
-
-### Arch Linux / Manjaro:
-
-```sh
-sudo pacman -S gtk3
-```
-
-### Debian / Ubuntu:
-```sh
-sudo apt install libgtk-3-dev
-```
+Please refer to [Linux & BSD backends](https://docs.rs/rfd/latest/rfd/#linux--bsd-backends) for information about the needed dependencies to be able to compile on Linux.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
 //! };
 //! ```
 //!
+//! # Important Notes before compiling!
+//!
 //! # Linux & BSD backends
 //!
 //! On Linux & BSDs, two backends are available, one using the [GTK3 Rust bindings](https://gtk-rs.org/)
@@ -47,11 +49,11 @@
 //! backend requires the C library and development headers to be installed to build RFD. The package
 //! names on various distributions are:
 //!
-//! | Distribution    | Package name |
+//! | Distribution    | Installation Command |
 //! | --------------- | ------------ |
-//! | Fedora          | gtk3-devel   |
-//! | Arch            | gtk3         |
-//! | Debian & Ubuntu | libgtk-3-dev |
+//! | Fedora          | apt install gtk3-devel   |
+//! | Arch            | apt install gtk3         |
+//! | Debian & Ubuntu | apt install libgtk-3-dev |
 //!
 //! ## XDG Desktop Portal backend
 //! The XDG Desktop Portal backend is used when the `gtk3` feature is disabled with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //! | Distribution    | Installation Command |
 //! | --------------- | ------------ |
-//! | Fedora          | apt install gtk3-devel   |
+//! | Fedora          | dnf install gtk3-devel   |
 //! | Arch            | apt install gtk3         |
 //! | Debian & Ubuntu | apt install libgtk-3-dev |
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! | Distribution    | Installation Command |
 //! | --------------- | ------------ |
 //! | Fedora          | dnf install gtk3-devel   |
-//! | Arch            | apt install gtk3         |
+//! | Arch            | pacman -S gtk3         |
 //! | Debian & Ubuntu | apt install libgtk-3-dev |
 //!
 //! ## XDG Desktop Portal backend

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,6 @@
 //! };
 //! ```
 //!
-//! # Important Notes before compiling!
-//!
 //! # Linux & BSD backends
 //!
 //! On Linux & BSDs, two backends are available, one using the [GTK3 Rust bindings](https://gtk-rs.org/)


### PR DESCRIPTION
when you try compiling any crate with `rfd` as a dependency without installing `libgtk` on linux, It'll always fail with this hard to debug error message, so better add a note here to aware people before compiling to linux.

This is also noted here in [`tao`](https://github.com/tauri-apps/tao#platform-specific-notes)

```sh
error: failed to run custom build command for `atk-sys v0.15.1`

Caused by:
  process didn't exit successfully: `/home/runner/work/deadliner/deadliner/target/debug/build/atk-sys-4862881347b4c8db/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=ATK_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:warning=`"pkg-config" "--libs" "--cflags" "atk" "atk >= 2.18"` did not exit successfully: exit status: 1
  error: could not find system library 'atk' required by the 'atk-sys' crate

  --- stderr
  Package atk was not found in the pkg-config search path.
  Perhaps you should add the directory containing `atk.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'atk' found
  Package atk was not found in the pkg-config search path.
  Perhaps you should add the directory containing `atk.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'atk' found

warning: build failed, waiting for other jobs to finish...
error: build failed
```