### PR TITLE
Allow windows crate version in 0.33-0.35 range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ block = "0.1.6"
 objc-foundation = "0.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.33", features = [
+windows = { version = ">= 0.33, <= 0.35", features = [
   "Win32_Foundation",
   "Win32_System_Com",
   "Win32_UI_Shell_Common",


### PR DESCRIPTION
This lowers the chance for crate duplication for users. However, we must make sure that `rfd` work with every version in the range. I don't have Wndows, so I can't check. The CI seems configured for windows, and should be trying the latest version (0.35), so if this PR passes CI we _should_ be good :)