### PR TITLE
feat: Add support for selecting multiple folders, fixes #68

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -50,6 +50,7 @@ pub trait FileSaveDialogImpl {
 /// Dialog used to pick folder
 pub trait FolderPickerDialogImpl {
     fn pick_folder(self) -> Option<PathBuf>;
+    fn pick_folders(self) -> Option<Vec<PathBuf>>;
 }
 
 pub trait MessageDialogImpl {
@@ -75,6 +76,7 @@ pub trait AsyncFilePickerDialogImpl {
 /// Dialog used to pick folder
 pub trait AsyncFolderPickerDialogImpl {
     fn pick_folder_async(self) -> DialogFutureType<Option<FileHandle>>;
+    fn pick_folders_async(self) -> DialogFutureType<Option<Vec<FileHandle>>>;
 }
 
 /// Dialog used to pick folder

--- a/src/backend/gtk3/file_dialog/dialog_ffi.rs
+++ b/src/backend/gtk3/file_dialog/dialog_ffi.rs
@@ -231,6 +231,28 @@ impl GtkFileDialog {
         dialog
     }
 
+    pub fn build_pick_folders(opt: &FileDialog) -> Self {
+        let dialog = GtkFileDialog::new(
+            opt.title.as_deref().unwrap_or("Select Folder"),
+            GtkFileChooserAction::SelectFolder,
+            "Cancel",
+            "Select",
+        );
+        unsafe { gtk_sys::gtk_file_chooser_set_select_multiple(dialog.ptr as _, 1) };
+        dialog.set_path(opt.starting_directory.as_deref());
+
+        if let (Some(mut path), Some(file_name)) =
+            (opt.starting_directory.to_owned(), opt.file_name.as_deref())
+        {
+            path.push(file_name);
+            dialog.set_file_name(path.deref().to_str());
+        } else {
+            dialog.set_file_name(opt.file_name.as_deref());
+        }
+
+        dialog
+    }
+
     pub fn build_pick_files(opt: &FileDialog) -> Self {
         let mut dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Open File"),

--- a/src/backend/macos/file_dialog/panel_ffi.rs
+++ b/src/backend/macos/file_dialog/panel_ffi.rs
@@ -233,6 +233,28 @@ impl Panel {
         panel
     }
 
+    pub fn build_pick_folders(opt: &FileDialog) -> Self {
+        let panel = Panel::open_panel();
+
+        if let Some(path) = &opt.starting_directory {
+            panel.set_path(path, opt.file_name.as_deref());
+        }
+
+        if let Some(title) = &opt.title {
+            panel.set_title(title);
+        }
+
+        if let Some(parent) = &opt.parent {
+            panel.set_parent(parent);
+        }
+
+        panel.set_can_choose_directories(YES);
+        panel.set_can_choose_files(NO);
+        panel.set_allows_multiple_selection(YES);
+
+        panel
+    }
+
     pub fn build_pick_files(opt: &FileDialog) -> Self {
         let panel = Panel::open_panel();
 

--- a/src/backend/win_cid/file_dialog.rs
+++ b/src/backend/win_cid/file_dialog.rs
@@ -73,12 +73,28 @@ impl FolderPickerDialogImpl for FileDialog {
 
         run(self).ok()
     }
+
+    fn pick_folders(self) -> Option<Vec<PathBuf>> {
+        fn run(opt: FileDialog) -> Result<Vec<PathBuf>> {
+            init_com(|| {
+                let dialog = IDialog::build_pick_folders(&opt)?;
+                dialog.show()?;
+                dialog.get_results()
+            })?
+        }
+        run(self).ok()
+    }
 }
 
 use crate::backend::AsyncFolderPickerDialogImpl;
 impl AsyncFolderPickerDialogImpl for FileDialog {
     fn pick_folder_async(self) -> DialogFutureType<Option<FileHandle>> {
         let ret = single_return_future(move || IDialog::build_pick_folder(&self));
+        Box::pin(ret)
+    }
+
+    fn pick_folders_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
+        let ret = multiple_return_future(move || IDialog::build_pick_folders(&self));
         Box::pin(ret)
     }
 }

--- a/src/backend/win_cid/file_dialog/dialog_ffi.rs
+++ b/src/backend/win_cid/file_dialog/dialog_ffi.rs
@@ -9,7 +9,7 @@ use windows::Win32::{
     UI::Shell::{
         Common::COMDLG_FILTERSPEC, FileOpenDialog, FileSaveDialog, IFileDialog, IFileOpenDialog,
         IFileSaveDialog, IShellItem, SHCreateItemFromParsingName, FOS_ALLOWMULTISELECT,
-        FOS_PICKFOLDERS, SIGDN_FILESYSPATH,
+        FOS_PICKFOLDERS, SIGDN_FILESYSPATH, FILEOPENDIALOGOPTIONS,
     },
 };
 
@@ -252,6 +252,20 @@ impl IDialog {
 
         unsafe {
             dialog.0.as_dialog().SetOptions(FOS_PICKFOLDERS as _)?;
+        }
+
+        Ok(dialog)
+    }
+
+    pub fn build_pick_folders(opt: &FileDialog) -> Result<Self> {
+        let dialog = IDialog::new_open_dialog(opt)?;
+
+        dialog.set_path(&opt.starting_directory)?;
+        dialog.set_title(&opt.title)?;
+        let opts = FILEOPENDIALOGOPTIONS(FOS_PICKFOLDERS.0 | FOS_ALLOWMULTISELECT.0);
+
+        unsafe {
+            dialog.0.as_dialog().SetOptions(opts)?;
         }
 
         Ok(dialog)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -105,6 +105,11 @@ impl FileDialog {
         FolderPickerDialogImpl::pick_folder(self)
     }
 
+    /// Pick multiple folders
+    pub fn pick_folders(self) -> Option<Vec<PathBuf>> {
+        FolderPickerDialogImpl::pick_folders(self)
+    }
+
     /// Opens save file dialog
     ///
     /// #### Platform specific notes regarding save dialog filters:
@@ -212,6 +217,14 @@ impl AsyncFileDialog {
     /// Does not exist in `WASM32`
     pub fn pick_folder(self) -> impl Future<Output = Option<FileHandle>> {
         AsyncFolderPickerDialogImpl::pick_folder_async(self.file_dialog)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    /// Pick multiple folders
+    ///
+    /// Does not exist in `WASM32`
+    pub fn pick_folders(self) -> impl Future<Output = Option<Vec<FileHandle>>> {
+        AsyncFolderPickerDialogImpl::pick_folders_async(self.file_dialog)
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Add support for multiple directories on all supported platforms.

This PR is essentially a copy-modify-paste job, with some added sanity checks that the APIs are stable and well supported. I have verified that both sync and async versions work correctly on:

- MacOS 12.3.1 on aarch64 (M1)
- Windows 10.0.19044 (x86_64)
- Ubuntu 20.04.4 LTS, Linux 5.4.0-117-generic (x86_64)
 
Thank you for an awesome library!