### PR TITLE
feat: customize button text, Close #72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ repository = "https://github.com/PolyMeilex/rfd"
 documentation = "https://docs.rs/rfd"
 
 [features]
-default = ["gtk3"]
+default = ["gtk3", "common-controls-v6"]
 file-handle-inner = []
 gtk3 = ["gtk-sys", "glib-sys", "gobject-sys", "lazy_static"]
 xdg-portal = ["ashpd", "urlencoding", "pollster"]
+common-controls-v6 = ["windows/Win32_UI_Controls"]
 
 [dev-dependencies]
 futures = "0.3.12"
@@ -69,6 +70,11 @@ wasm-bindgen-futures = "0.4.19"
 name = "simple"
 [[example]]
 name = "async"
+[[example]]
+name = "msg-custom-buttons"
 
 [package.metadata.docs.rs]
 features = ["file-handle-inner"]
+
+[build-dependencies]
+embed-resource = "1.6"

--- a/app.exe.manifest
+++ b/app.exe.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<dependency>
+    <dependentAssembly>
+        <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
+        />
+    </dependentAssembly>
+</dependency>
+</assembly>

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+extern crate embed_resource;
+
 fn main() {
     let target = std::env::var("TARGET").unwrap();
 
@@ -10,4 +12,7 @@ fn main() {
 
     #[cfg(not(any(feature = "gtk3", feature = "xdg-portal")))]
     compile_error!("You need to choose at least one backend: `gtk3` or `xdg-portal` features");
+
+    #[cfg(all(target_os = "windows", feature = "common-controls-v6"))]
+    embed_resource::compile("manifest.rc");
 }

--- a/examples/msg-custom-buttons.rs
+++ b/examples/msg-custom-buttons.rs
@@ -1,0 +1,26 @@
+fn main() {
+    #[cfg(not(feature = "gtk3"))]
+    let res = "";
+
+    #[cfg(any(
+        target_os = "windows",
+        target_os = "macos",
+        all(
+            any(
+                target_os = "linux",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ),
+            feature = "gtk3"
+        )
+    ))]
+    let res = rfd::MessageDialog::new()
+        .set_title("Msg!")
+        .set_description("Description!")
+        .set_buttons(rfd::MessageButtons::OkCancelCustom("Got it!".to_string(), "No!".to_string()))
+        .show();
+
+    println!("{}", res);
+}

--- a/manifest.rc
+++ b/manifest.rc
@@ -1,0 +1,2 @@
+#define RT_MANIFEST 24
+1 RT_MANIFEST "app.exe.manifest"

--- a/src/backend/macos/message_dialog.rs
+++ b/src/backend/macos/message_dialog.rs
@@ -54,23 +54,32 @@ impl NSAlert {
             let _: () = msg_send![alert, setAlertStyle: level as i64];
         }
 
-        match opt.buttons {
-            MessageButtons::Ok => unsafe {
-                let label = NSString::from_str("OK");
+        let buttons = match opt.buttons {
+            MessageButtons::Ok => vec![
+                "OK".to_owned(),
+            ],
+            MessageButtons::OkCancel => vec![
+                "OK".to_owned(),
+                "Cancel".to_owned(),
+            ],
+            MessageButtons::YesNo => vec![
+                "Yes".to_owned(),
+                "No".to_owned(),
+            ],
+            MessageButtons::OkCustom(ok_text) => vec![
+                ok_text,
+            ],
+            MessageButtons::OkCancelCustom(ok_text, cancel_text) => vec![
+                ok_text,
+                cancel_text,
+            ],
+        };
+
+        for button in buttons {
+            unsafe {
+                let label = NSString::from_str(&button);
                 let _: () = msg_send![alert, addButtonWithTitle: label];
-            },
-            MessageButtons::OkCancel => unsafe {
-                let label = NSString::from_str("OK");
-                let _: () = msg_send![alert, addButtonWithTitle: label];
-                let label = NSString::from_str("Cancel");
-                let _: () = msg_send![alert, addButtonWithTitle: label];
-            },
-            MessageButtons::YesNo => unsafe {
-                let label = NSString::from_str("Yes");
-                let _: () = msg_send![alert, addButtonWithTitle: label];
-                let label = NSString::from_str("No");
-                let _: () = msg_send![alert, addButtonWithTitle: label];
-            },
+            }
         }
 
         unsafe {

--- a/src/backend/wasm.rs
+++ b/src/backend/wasm.rs
@@ -178,11 +178,11 @@ impl MessageDialogImpl for MessageDialog {
     fn show(self) -> bool {
         let text = format!("{}\n{}", self.title, self.description);
         match self.buttons {
-            MessageButtons::Ok => {
+            MessageButtons::Ok | MessageButtons::OkCustom(_) => {
                 alert(&text);
                 true
             }
-            MessageButtons::OkCancel | MessageButtons::YesNo => confirm(&text),
+            MessageButtons::OkCancel | MessageButtons::YesNo | MessageButtons::OkCancelCustom(_, _) => confirm(&text),
         }
     }
 }

--- a/src/message_dialog.rs
+++ b/src/message_dialog.rs
@@ -153,11 +153,17 @@ impl Default for MessageLevel {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum MessageButtons {
     Ok,
     OkCancel,
     YesNo,
+    /// One customizable button.
+    /// Notice that in Windows, this only works with the feature *common-controls-v6* enabled
+    OkCustom(String),
+    /// Two customizable buttons.
+    /// Notice that in Windows, this only works with the feature *common-controls-v6* enabled
+    OkCancelCustom(String, String)
 }
 
 impl Default for MessageButtons {


### PR DESCRIPTION
Use `TaskDialogIndirect` to show the message dialog because it supports customizing button texts.

Besides, `TaskDialogIndirect` has a nicer look than `MessageBoxW`.

MessageBoxW:
![Screenshot 2022-06-12 213009](https://user-images.githubusercontent.com/4006436/173235621-38f0c0be-80d6-4e50-958c-f5b169086372.png)

TaskDialogIndirect:
![Screenshot 2022-06-12 212229](https://user-images.githubusercontent.com/4006436/173235564-12ffbaba-debf-4437-9887-6722f1bcabd1.png)

While `TaskDialogIndirect` is only available with comctl32 version 6, but the OS inbox version is stuck at 5.x.  (ref https://github.com/microsoft/windows-rs/issues/1294#issuecomment-963417891)
So I added a cargo feature named`common-controls-v6` for enabling v6.

The change has been tested on Windows, Linux and macOS, but not on WASM.