### PR TITLE
fix: add level icon to the new windows dialog

### DIFF
--- a/examples/message-custom-buttons/src/main.rs
+++ b/examples/message-custom-buttons/src/main.rs
@@ -19,6 +19,7 @@ fn main() {
     let res = rfd::MessageDialog::new()
         .set_title("Msg!")
         .set_description("Description!")
+        .set_level(rfd::MessageLevel::Warning)
         .set_buttons(rfd::MessageButtons::OkCancelCustom("Got it!".to_string(), "No!".to_string()))
         .show();
 


### PR DESCRIPTION
`TD_WARNING_ICON` / `TD_ERROR_ICON` / `TD_INFORMATION_ICON` are missing so I use hard code to workaround.

Or we can wait for https://github.com/microsoft/win32metadata/issues/968 to be fixed, but I don't know how long will it be.