### PR TITLE
chore(deps): update `raw-window-handle` to `0.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ common-controls-v6 = ["windows/Win32_UI_Controls"]
 futures = "0.3.12"
 
 [dependencies]
-raw-window-handle = "0.4.1"
+raw-window-handle = "0.5"
 log = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
`winit` and `tao` has already published new versions with `raw-window-handle 0.5` but we can't update `tauri` until `rfd` also publishes a new version with `raw-window-handle 0.5`