### PR TITLE
Use const init instead of `lazy_static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/rfd"
 [features]
 default = ["gtk3"]
 file-handle-inner = []
-gtk3 = ["gtk-sys", "glib-sys", "gobject-sys", "lazy_static"]
+gtk3 = ["gtk-sys", "glib-sys", "gobject-sys"]
 xdg-portal = ["ashpd", "urlencoding", "pollster"]
 common-controls-v6 = ["windows/Win32_UI_Controls"]
 
@@ -49,7 +49,6 @@ pollster = { version = "0.2", optional = true }
 gtk-sys = { version = "0.15.1", features = ["v3_20"], optional = true }
 glib-sys = { version = "0.15.1", optional = true }
 gobject-sys = { version = "0.15.1", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.69"

--- a/src/backend/gtk3/utils.rs
+++ b/src/backend/gtk3/utils.rs
@@ -1,5 +1,3 @@
-use lazy_static::lazy_static;
-
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -14,7 +12,7 @@ unsafe impl Send for GtkGlobalMutex {}
 unsafe impl Sync for GtkGlobalMutex {}
 
 impl GtkGlobalMutex {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             locker: Mutex::new(()),
         }
@@ -26,9 +24,7 @@ impl GtkGlobalMutex {
     }
 }
 
-lazy_static! {
-    pub static ref GTK_MUTEX: GtkGlobalMutex = GtkGlobalMutex::new();
-}
+pub static GTK_MUTEX: GtkGlobalMutex = GtkGlobalMutex::new();
 
 /// # Event Handler
 /// Counts amout of iteration requests
@@ -42,12 +38,10 @@ pub struct GtkEventHandler {
 unsafe impl Send for GtkEventHandler {}
 unsafe impl Sync for GtkEventHandler {}
 
-lazy_static! {
-    pub static ref GTK_EVENT_HANDLER: GtkEventHandler = GtkEventHandler::new();
-}
+pub static GTK_EVENT_HANDLER: GtkEventHandler = GtkEventHandler::new();
 
 impl GtkEventHandler {
-    fn new() -> Self {
+    const fn new() -> Self {
         let thread = Mutex::new(None);
         let request_count = AtomicUsize::new(0);
         Self {


### PR DESCRIPTION
Split into two commit to simplify the review.

The MSRV for const `Mutex::new()` is 1.63.
I couldn't find the published MSRV for this crate, so I don't know if that's ok.