### PR TITLE
Update gtk to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ ashpd = { version = "0.3", optional = true }
 urlencoding = { version = "2.1.0", optional = true }
 pollster = { version = "0.2", optional = true }
 # GTK
-gtk-sys = { version = "0.15.1", features = ["v3_20"], optional = true }
-glib-sys = { version = "0.15.1", optional = true }
-gobject-sys = { version = "0.15.1", optional = true }
+gtk-sys = { version = "0.16", features = ["v3_24"], optional = true }
+glib-sys = { version = "0.16", optional = true }
+gobject-sys = { version = "0.16", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.69"


### PR DESCRIPTION
We are upgrading to gtk 0.16. Could this crate also bump a version for it?