### PR TITLE
Update pollster to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ windows = { version = "0.44", features = [
 # XDG Desktop Portal
 ashpd = { version = "0.3", optional = true }
 urlencoding = { version = "2.1.0", optional = true }
-pollster = { version = "0.2", optional = true }
+pollster = { version = "0.3", optional = true }
 # GTK
 gtk-sys = { version = "0.16", features = ["v3_24"], optional = true }
 glib-sys = { version = "0.16", optional = true }


### PR DESCRIPTION
Switching our project to use xdg-portal and and now have mismatched pollster with some other deps (namely eframe). Would be awesome we we could bump the pollster dep here.

Looks like a minor change that should be compatible.