### PR TITLE
Change a few method signatures

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -45,7 +45,7 @@ impl FileDialog {
     ///   * Linux
     ///
     /// On platforms that don't support filter names, all filters will be merged into one filter
-    pub fn add_filter(mut self, name: &str, extensions: &[&str]) -> Self {
+    pub fn add_filter(mut self, name: impl Into<String>, extensions: &[impl ToString]) -> Self {
         self.filters.push(Filter {
             name: name.into(),
             extensions: extensions.iter().map(|e| e.to_string()).collect(),
@@ -71,7 +71,7 @@ impl FileDialog {
     ///  * Windows
     ///  * Linux
     ///  * Mac
-    pub fn set_file_name(mut self, file_name: &str) -> Self {
+    pub fn set_file_name(mut self, file_name: impl Into<String>) -> Self {
         self.file_name = Some(file_name.into());
         self
     }
@@ -80,7 +80,7 @@ impl FileDialog {
     ///  * Windows
     ///  * Linux
     ///  * Mac (Only below version 10.11)
-    pub fn set_title(mut self, title: &str) -> Self {
+    pub fn set_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }
@@ -163,7 +163,7 @@ impl AsyncFileDialog {
     ///   * Linux
     ///
     /// On platforms that don't support filter names, all filters will be merged into one filter
-    pub fn add_filter(mut self, name: &str, extensions: &[&str]) -> Self {
+    pub fn add_filter(mut self, name: impl Into<String>, extensions: &[impl ToString]) -> Self {
         self.file_dialog = self.file_dialog.add_filter(name, extensions);
         self
     }
@@ -181,7 +181,7 @@ impl AsyncFileDialog {
     ///  * Windows
     ///  * Linux
     ///  * Mac
-    pub fn set_file_name(mut self, file_name: &str) -> Self {
+    pub fn set_file_name(mut self, file_name: impl Into<String>) -> Self {
         self.file_dialog = self.file_dialog.set_file_name(file_name);
         self
     }
@@ -190,7 +190,7 @@ impl AsyncFileDialog {
     ///  * Windows
     ///  * Linux
     ///  * Mac (Only below version 10.11)
-    pub fn set_title(mut self, title: &str) -> Self {
+    pub fn set_title(mut self, title: impl Into<String>) -> Self {
         self.file_dialog = self.file_dialog.set_title(title);
         self
     }

--- a/src/message_dialog.rs
+++ b/src/message_dialog.rs
@@ -38,7 +38,7 @@ impl MessageDialog {
     }
 
     /// Set title of a dialog
-    pub fn set_title(mut self, text: &str) -> Self {
+    pub fn set_title(mut self, text: impl Into<String>) -> Self {
         self.title = text.into();
         self
     }
@@ -46,7 +46,7 @@ impl MessageDialog {
     /// Set description of a dialog
     ///
     /// Description is a content of a dialog
-    pub fn set_description(mut self, text: &str) -> Self {
+    pub fn set_description(mut self, text: impl Into<String>) -> Self {
         self.description = text.into();
         self
     }
@@ -101,7 +101,7 @@ impl AsyncMessageDialog {
     }
 
     /// Set title of a dialog
-    pub fn set_title(mut self, text: &str) -> Self {
+    pub fn set_title(mut self, text: impl Into<String>) -> Self {
         self.0 = self.0.set_title(text);
         self
     }
@@ -109,7 +109,7 @@ impl AsyncMessageDialog {
     /// Set description of a dialog
     ///
     /// Description is a content of a dialog
-    pub fn set_description(mut self, text: &str) -> Self {
+    pub fn set_description(mut self, text: impl Into<String>) -> Self {
         self.0 = self.0.set_description(text);
         self
     }


### PR DESCRIPTION
## Summary
Change a few method signatures to accept `impl Into<String>`, instead of `&str`

## Motivation
Currently, several methods like [`MessageDialog::set_title`](https://docs.rs/rfd/latest/rfd/struct.MessageDialog.html#method.set_title), [`MessageDialog::set_description`](https://docs.rs/rfd/latest/rfd/struct.MessageDialog.html#method.set_description) or [`FileDialog::add_filter`](https://docs.rs/rfd/latest/rfd/struct.FileDialog.html#method.add_filter) accept `&str` as one of the arguments - this is extremely inconvenient, as if you have a [`String`](https://doc.rust-lang.org/std/string/struct.String.html) from [`format!`](https://doc.rust-lang.org/std/macro.format.html) macro, one has to convert it to `&str` and sometimes it may not be possible, due to the borrow checker.
*And* internally - titles, descriptions, extensions, etc. are stored as [`String`](https://doc.rust-lang.org/std/string/struct.String.html)s, so it'd make more sense to convert anything to a [`String`](https://doc.rust-lang.org/std/string/struct.String.html) in the methods themselves.

### Why `Into<String>` and not [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html)?
To tackle this question, we first need to know the difference between two traits.

[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) - converts the value to [`String`](https://doc.rust-lang.org/std/string/struct.String.html) without consuming it.
`Into<String>` - *consumes* the value while converting it to a [`String`](https://doc.rust-lang.org/std/string/struct.String.html).

All methods in this PR use the arguments to show data in message boxes - therefore it's most unlikely for that data to be used after the message box is shown.
If one *really* needs to use the argument after a method from `rfd`, one can *clone* or *copy* the value.

## Compatibility with existing codebases
This PR doesn't require *any* overhaul for the users of the library, as `&str` implements both `Into<String>` and [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html)