### PR TITLE
Add support for Yes/No/Cancel buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/examples/message-custom-buttons/Cargo.toml
+++ b/examples/message-custom-buttons/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rfd = {version = "0.9.0", path = "../..", features=["common-controls-v6"]}
+rfd = {version = "0.10.0", path = "../..", features=["common-controls-v6"]}
 
 [build-dependencies]
 embed-resource = "1.6"

--- a/examples/message-custom-buttons/src/main.rs
+++ b/examples/message-custom-buttons/src/main.rs
@@ -23,5 +23,26 @@ fn main() {
         .set_buttons(rfd::MessageButtons::OkCancelCustom("Got it!".to_string(), "No!".to_string()))
         .show();
 
+    #[cfg(any(
+        target_os = "windows",
+        target_os = "macos",
+        all(
+            any(
+                target_os = "linux",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ),
+            feature = "gtk3"
+        )
+    ))]
+    let res = rfd::MessageDialog::new()
+        .set_title("Do you want to save the changes you made?")
+        .set_description("Your changes will be lost if you don't save them.")
+        .set_level(rfd::MessageLevel::Warning)
+        .set_buttons(rfd::MessageButtons::YesNoCancelCustom("Save".to_string(), "Don't Save".to_string(), "Cancel".to_string()))
+        .show();
+
     println!("{}", res);
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,3 +1,4 @@
+use crate::message_dialog::MessageDialogResult;
 use crate::FileHandle;
 use std::future::Future;
 use std::path::PathBuf;
@@ -54,7 +55,7 @@ pub trait FolderPickerDialogImpl {
 }
 
 pub trait MessageDialogImpl {
-    fn show(self) -> bool;
+    fn show(self) -> MessageDialogResult;
 }
 
 //
@@ -85,5 +86,5 @@ pub trait AsyncFileSaveDialogImpl {
 }
 
 pub trait AsyncMessageDialogImpl {
-    fn show_async(self) -> DialogFutureType<bool>;
+    fn show_async(self) -> DialogFutureType<MessageDialogResult>;
 }

--- a/src/backend/gtk3/message_dialog.rs
+++ b/src/backend/gtk3/message_dialog.rs
@@ -30,6 +30,7 @@ impl GtkMessageDialog {
             MessageButtons::YesNoCancel => gtk_sys::GTK_BUTTONS_NONE,
             MessageButtons::OkCustom(_) => gtk_sys::GTK_BUTTONS_NONE,
             MessageButtons::OkCancelCustom(_, _) => gtk_sys::GTK_BUTTONS_NONE,
+            MessageButtons::YesNoCancelCustom(_, _, _) => gtk_sys::GTK_BUTTONS_NONE,
         };
 
         let custom_buttons = match &opt.buttons {
@@ -58,6 +59,15 @@ impl GtkMessageDialog {
                     CString::new(cancel_text.as_bytes()).unwrap(),
                     gtk_sys::GTK_RESPONSE_CANCEL,
                 )),
+            ],
+            MessageButtons::YesNoCancelCustom(yes_text, no_text, cancel_text) => vec![
+                Some((CString::new(yes_text).unwrap(), gtk_sys::GTK_RESPONSE_YES)),
+                Some((CString::new(no_text).unwrap(), gtk_sys::GTK_RESPONSE_NO)),
+                Some((
+                    CString::new(cancel_text).unwrap(),
+                    gtk_sys::GTK_RESPONSE_CANCEL,
+                )),
+                None,
             ],
             _ => vec![],
         };
@@ -122,6 +132,15 @@ impl GtkMessageDialog {
                 MessageDialogResult::Custom(custom.to_owned())
             }
             (OkCancelCustom(_, custom), gtk_sys::GTK_RESPONSE_CANCEL) => {
+                MessageDialogResult::Custom(custom.to_owned())
+            }
+            (YesNoCancelCustom(custom, _, _), gtk_sys::GTK_RESPONSE_YES) => {
+                MessageDialogResult::Custom(custom.to_owned())
+            },
+            (YesNoCancelCustom(_, custom, _), gtk_sys::GTK_RESPONSE_NO) => {
+                MessageDialogResult::Custom(custom.to_owned())
+            },
+            (YesNoCancelCustom(_, _, custom), gtk_sys::GTK_RESPONSE_CANCEL) => {
                 MessageDialogResult::Custom(custom.to_owned())
             }
             _ => MessageDialogResult::Cancel,

--- a/src/backend/macos/message_dialog.rs
+++ b/src/backend/macos/message_dialog.rs
@@ -66,6 +66,9 @@ impl NSAlert {
             MessageButtons::OkCancelCustom(ok_text, cancel_text) => {
                 vec![ok_text.to_owned(), cancel_text.to_owned()]
             }
+            MessageButtons::YesNoCancelCustom(yes_text, no_text, cancel_text) => {
+                vec![yes_text.to_owned(), no_text.to_owned(), cancel_text.to_owned()]
+            }
         };
 
         for button in buttons {
@@ -129,6 +132,15 @@ fn dialog_result(buttons: &MessageButtons, ret: i64) -> MessageDialogResult {
             MessageDialogResult::Custom(custom.to_owned())
         }
         MessageButtons::OkCancelCustom(_, custom) if ret == NSAlertReturn::SecondButton as i64 => {
+            MessageDialogResult::Custom(custom.to_owned())
+        }
+        MessageButtons::YesNoCancelCustom(custom, _, _) if ret == NSAlertReturn::FirstButton as i64 => {
+            MessageDialogResult::Custom(custom.to_owned())
+        }
+        MessageButtons::YesNoCancelCustom(_, custom, _) if ret == NSAlertReturn::SecondButton as i64 => {
+            MessageDialogResult::Custom(custom.to_owned())
+        }
+        MessageButtons::YesNoCancelCustom(_, _, custom) if ret == NSAlertReturn::ThirdButton as i64 => {
             MessageDialogResult::Custom(custom.to_owned())
         }
         _ => MessageDialogResult::Cancel,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,4 +168,6 @@ mod message_dialog;
         feature = "gtk3"
     )
 ))]
-pub use message_dialog::{AsyncMessageDialog, MessageButtons, MessageDialog, MessageLevel};
+pub use message_dialog::{
+    AsyncMessageDialog, MessageButtons, MessageDialog, MessageDialogResult, MessageLevel,
+};

--- a/src/message_dialog.rs
+++ b/src/message_dialog.rs
@@ -173,11 +173,12 @@ impl Default for MessageButtons {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum MessageDialogResult {
     Yes,
     No,
     Ok,
+    #[default]
     Cancel,
     Custom(String),
 }

--- a/src/message_dialog.rs
+++ b/src/message_dialog.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use crate::backend::AsyncMessageDialogImpl;
 use crate::backend::MessageDialogImpl;
 
@@ -54,8 +55,9 @@ impl MessageDialog {
     /// Set the set of button that will be displayed on the dialog
     ///
     /// - `Ok` dialog is a single `Ok` button
-    /// - `OkCancel` dialog, will display 2 buttons ok and cancel.
-    /// - `YesNo` dialog, will display 2 buttons yes and no.
+    /// - `OkCancel` dialog, will display 2 buttons: ok and cancel.
+    /// - `YesNo` dialog, will display 2 buttons: yes and no.
+    /// - `YesNoCancel` dialog, will display 3 buttons: yes, no, and cancel.
     pub fn set_buttons(mut self, btn: MessageButtons) -> Self {
         self.buttons = btn;
         self
@@ -68,11 +70,7 @@ impl MessageDialog {
         self
     }
 
-    /// Shows a message dialog:
-    ///
-    /// - In `Ok` dialog, it will return `true` when `OK` was pressed
-    /// - In `OkCancel` dialog, it will return `true` when `OK` was pressed
-    /// - In `YesNo` dialog, it will return `true` when `Yes` was pressed
+    /// Shows a message dialog and returns the button that was pressed.
     pub fn show(self) -> MessageDialogResult {
         MessageDialogImpl::show(self)
     }
@@ -119,6 +117,7 @@ impl AsyncMessageDialog {
     /// - `Ok` dialog is a single `Ok` button
     /// - `OkCancel` dialog, will display 2 buttons ok and cancel.
     /// - `YesNo` dialog, will display 2 buttons yes and no.
+    /// - `YesNoCancel` dialog, will display 3 buttons: yes, no, and cancel.
     pub fn set_buttons(mut self, btn: MessageButtons) -> Self {
         self.0 = self.0.set_buttons(btn);
         self
@@ -131,10 +130,7 @@ impl AsyncMessageDialog {
         self
     }
 
-    /// Shows a message dialog:
-    /// - In `Ok` dialog, it will return `true` when `OK` was pressed
-    /// - In `OkCancel` dialog, it will return `true` when `OK` was pressed
-    /// - In `YesNo` dialog, it will return `true` when `Yes` was pressed
+    /// Shows a message dialog and returns the button that was pressed.
     pub fn show(self) -> impl Future<Output = MessageDialogResult> {
         AsyncMessageDialogImpl::show_async(self.0)
     }
@@ -165,6 +161,9 @@ pub enum MessageButtons {
     /// Two customizable buttons.
     /// Notice that in Windows, this only works with the feature *common-controls-v6* enabled
     OkCancelCustom(String, String),
+    /// Three customizable buttons.
+    /// Notice that in Windows, this only works with the feature *common-controls-v6* enabled
+    YesNoCancelCustom(String, String, String),
 }
 
 impl Default for MessageButtons {
@@ -181,4 +180,16 @@ pub enum MessageDialogResult {
     #[default]
     Cancel,
     Custom(String),
+}
+
+impl Display for MessageDialogResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Self::Yes => "Yes".to_string(),
+            Self::No => "No".to_string(),
+            Self::Ok => "Ok".to_string(),
+            Self::Cancel => "Cancel".to_string(),
+            Self::Custom(custom) => format!("Custom({custom})"),
+        })
+    }
 }

--- a/src/message_dialog.rs
+++ b/src/message_dialog.rs
@@ -73,7 +73,7 @@ impl MessageDialog {
     /// - In `Ok` dialog, it will return `true` when `OK` was pressed
     /// - In `OkCancel` dialog, it will return `true` when `OK` was pressed
     /// - In `YesNo` dialog, it will return `true` when `Yes` was pressed
-    pub fn show(self) -> bool {
+    pub fn show(self) -> MessageDialogResult {
         MessageDialogImpl::show(self)
     }
 }
@@ -135,7 +135,7 @@ impl AsyncMessageDialog {
     /// - In `Ok` dialog, it will return `true` when `OK` was pressed
     /// - In `OkCancel` dialog, it will return `true` when `OK` was pressed
     /// - In `YesNo` dialog, it will return `true` when `Yes` was pressed
-    pub fn show(self) -> impl Future<Output = bool> {
+    pub fn show(self) -> impl Future<Output = MessageDialogResult> {
         AsyncMessageDialogImpl::show_async(self.0)
     }
 }
@@ -158,6 +158,7 @@ pub enum MessageButtons {
     Ok,
     OkCancel,
     YesNo,
+    YesNoCancel,
     /// One customizable button.
     /// Notice that in Windows, this only works with the feature *common-controls-v6* enabled
     OkCustom(String),
@@ -170,4 +171,13 @@ impl Default for MessageButtons {
     fn default() -> Self {
         Self::Ok
     }
+}
+
+#[derive(Debug)]
+pub enum MessageDialogResult {
+    Yes,
+    No,
+    Ok,
+    Cancel,
+    Custom(String),
 }


### PR DESCRIPTION
Fixes #81 

I based this off of this fork: https://github.com/zphixon/rfd

The Yes/No/Cancel provided by the OS seem to work fine on Linux and macOS, however:
- Didn't compile on Windows,
- There was no support for custom text in the 3 buttons.

I addressed both of these issues and updated the documentation of `MessageDialog` accordingly.

Tested on Windows only, I'll confirm if Linux works later today.