### PR TITLE
Add Create folder button to pick_folder on macOS

### DIFF
--- a/src/backend/macos/file_dialog/panel_ffi.rs
+++ b/src/backend/macos/file_dialog/panel_ffi.rs
@@ -70,6 +70,10 @@ impl Panel {
         let _: () = unsafe { msg_send![self.panel, setCanChooseDirectories: v] };
     }
 
+    pub fn set_can_create_directories(&self, v: BOOL) {
+        let _: () = unsafe { msg_send![self.panel, setCanCreateDirectories: v] };
+    }
+
     pub fn set_can_choose_files(&self, v: BOOL) {
         let _: () = unsafe { msg_send![self.panel, setCanChooseFiles: v] };
     }
@@ -228,6 +232,7 @@ impl Panel {
         }
 
         panel.set_can_choose_directories(YES);
+        panel.set_can_create_directories(YES);
         panel.set_can_choose_files(NO);
 
         panel
@@ -249,6 +254,7 @@ impl Panel {
         }
 
         panel.set_can_choose_directories(YES);
+        panel.set_can_create_directories(YES);
         panel.set_can_choose_files(NO);
         panel.set_allows_multiple_selection(YES);
 


### PR DESCRIPTION
On Windows and Linux the folder pickers all have Create folder button but macOS does not.

On macOS `NSSavePanel` has `canCreateDirectories` set to `YES` by default. `NSOpenPanel` inherits from `NSSavePanel` but has `canCreateDirectories` set to `NO` by default.

Windows:

<img width="878" alt="Screenshot 2023-07-28 at 16 33 48" src="https://github.com/PolyMeilex/rfd/assets/367440/41a5913b-58a3-4abe-b6d8-15eb70fee22b">

Linux:

<img width="1206" alt="Screenshot 2023-07-28 at 16 30 54" src="https://github.com/PolyMeilex/rfd/assets/367440/cc0b67e9-c7b1-4028-80e8-4dc098732947">

macOS (before the change):

<img width="801" alt="Screenshot 2023-07-28 at 16 35 05" src="https://github.com/PolyMeilex/rfd/assets/367440/153af754-2c09-435c-9a31-7b718d7e265f">

macOS (after the change):

<img width="801" alt="Screenshot 2023-07-28 at 16 51 11" src="https://github.com/PolyMeilex/rfd/assets/367440/a0278f4b-d952-4ced-91ec-a1d68bdb7c33">
