### PR TITLE
Use portals by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+- Use XDG Portal as default
 - Use zenity as a fallback for xdgp
 - Update `raw-window-handle` to 0.6.
 - Update `winit` in example to 0.29.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/PolyMeilex/rfd"
 documentation = "https://docs.rs/rfd"
 
 [features]
-default = ["gtk3"]
+default = ["xdg-portal"]
 file-handle-inner = []
 gtk3 = ["gtk-sys", "glib-sys", "gobject-sys"]
 xdg-portal = ["ashpd", "urlencoding", "pollster"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/PolyMeilex/rfd"
 documentation = "https://docs.rs/rfd"
 
 [features]
-default = ["xdg-portal"]
+default = ["xdg-portal", "async-std"]
 file-handle-inner = []
 gtk3 = ["gtk-sys", "glib-sys", "gobject-sys"]
 xdg-portal = ["ashpd", "urlencoding", "pollster"]


### PR DESCRIPTION
It can be safely assumed that a system has portals by default; if they don't, many things will simply fail to work, including, but not limited to, the dark mode preference and many other freedesktop settings.

Those that absolutely refuse to use D-Bus will thus end up with an unusable system in the first place, if they want to use anything desktop-related. So enabling the portal backend by default is fine.

GTK will, of course, fall back to using the portals if it's running inside of a Flatpak environment, but it requires manual workarounds outside of one. And, of course, having a library depend on GTK when it's more or less unnecessary isn't ideal.

Closes (although it's already closed) https://github.com/PolyMeilex/rfd/issues/99