### PR TITLE
wasm `save_file`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,14 @@ web-sys = { version = "0.3.46", features = [
   'Element',
   'HtmlInputElement',
   'HtmlButtonElement',
+  'HtmlAnchorElement',
   'Window',
   'File',
   'FileList',
   'FileReader',
+  'Blob',
+  'BlobPropertyBag',
+  'Url',
 ] }
 wasm-bindgen-futures = "0.4.19"
 

--- a/examples/winit-example/src/main.rs
+++ b/examples/winit-example/src/main.rs
@@ -41,7 +41,6 @@ fn main() {
         }
         event::Event::WindowEvent { event, .. } => match event {
             WindowEvent::CloseRequested { .. } => *control_flow = ControlFlow::Exit,
-            #[cfg(not(target_arch = "wasm32"))]
             WindowEvent::KeyboardInput {
                 input:
                     event::KeyboardInput {
@@ -60,6 +59,16 @@ fn main() {
                 let event_loop_proxy = event_loop_proxy.clone();
                 executor.execut(async move {
                     let file = dialog.await;
+
+                    let file = if let Some(file) = file {
+                        file.write(b"Hi! This is a test file".to_vec().into_boxed_slice())
+                            .await
+                            .unwrap();
+                        Some(file)
+                    } else {
+                        None
+                    };
+
                     event_loop_proxy
                         .send_event(format!("saved file name: {:#?}", file))
                         .ok();

--- a/examples/winit-example/src/main.rs
+++ b/examples/winit-example/src/main.rs
@@ -61,9 +61,7 @@ fn main() {
                     let file = dialog.await;
 
                     let file = if let Some(file) = file {
-                        file.write(b"Hi! This is a test file".to_vec().into_boxed_slice())
-                            .await
-                            .unwrap();
+                        file.write(b"Hi! This is a test file").await.unwrap();
                         Some(file)
                     } else {
                         None

--- a/src/backend/wasm.rs
+++ b/src/backend/wasm.rs
@@ -321,12 +321,13 @@ impl crate::backend::AsyncMessageDialogImpl for MessageDialog {
 }
 
 impl FileHandle {
-    pub async fn write(&self, data: Box<[u8]>) {
+    pub async fn write(&self, data: Box<[u8]>) -> std::io::Result<()> {
         let dialog = match &self.0 {
             WasmFileHandleKind::Writable(dialog) => dialog,
             _ => panic!("This File Handle doesn't support writing. Use `save_file` to get a writeable FileHandle in Wasm"),
         };
         let dialog = WasmDialog::new(&FileKind::Out(dialog.clone(), data));
         dialog.show().await;
+        Ok(())
     }
 }

--- a/src/backend/wasm.rs
+++ b/src/backend/wasm.rs
@@ -1,3 +1,5 @@
+mod file_dialog;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::Element;

--- a/src/backend/wasm.rs
+++ b/src/backend/wasm.rs
@@ -1,26 +1,40 @@
 mod file_dialog;
 
+use crate::{
+    file_dialog::FileDialog, file_handle::WasmFileHandleKind, FileHandle, MessageDialogResult,
+};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys::Element;
+use web_sys::{Element, HtmlAnchorElement, HtmlButtonElement, HtmlElement, HtmlInputElement};
 
-use web_sys::{HtmlButtonElement, HtmlElement, HtmlInputElement};
+#[derive(Clone, Debug)]
+pub enum FileKind {
+    In(FileDialog),
+    Out(FileDialog, Box<[u8]>),
+}
 
-use crate::file_dialog::FileDialog;
-use crate::{FileHandle, MessageDialogResult};
+#[derive(Clone, Debug)]
+enum HtmlIoElement {
+    Input(HtmlInputElement),
+    Output {
+        element: HtmlAnchorElement,
+        name: String,
+        data: Box<[u8]>,
+    },
+}
 
 pub struct WasmDialog {
     overlay: Element,
     card: Element,
     title: Option<HtmlElement>,
-    input: HtmlInputElement,
+    io: HtmlIoElement,
     button: HtmlButtonElement,
 
     style: Element,
 }
 
 impl WasmDialog {
-    pub fn new(opt: &FileDialog) -> Self {
+    pub fn new(opt: &FileKind) -> Self {
         let window = web_sys::window().expect("Window not found");
         let document = window.document().expect("Document not found");
 
@@ -35,9 +49,13 @@ impl WasmDialog {
             card
         };
 
-        let title = opt.title.as_ref().map(|title| {
-            let title_el: web_sys::HtmlElement =
-                document.create_element("div").unwrap().dyn_into().unwrap();
+        let title = match opt {
+            FileKind::In(dialog) => &dialog.title,
+            FileKind::Out(dialog, _) => &dialog.title,
+        }
+        .as_ref()
+        .map(|title| {
+            let title_el: HtmlElement = document.create_element("div").unwrap().dyn_into().unwrap();
 
             title_el.set_id("rfd-title");
             title_el.set_inner_html(title);
@@ -46,25 +64,41 @@ impl WasmDialog {
             title_el
         });
 
-        let input = {
-            let input_el = document.create_element("input").unwrap();
-            let input: HtmlInputElement = wasm_bindgen::JsCast::dyn_into(input_el).unwrap();
+        let io = match opt {
+            FileKind::In(dialog) => {
+                let input_el = document.create_element("input").unwrap();
+                let input: HtmlInputElement = wasm_bindgen::JsCast::dyn_into(input_el).unwrap();
 
-            input.set_id("rfd-input");
-            input.set_type("file");
+                input.set_id("rfd-input");
+                input.set_type("file");
 
-            let mut accept: Vec<String> = Vec::new();
+                let mut accept: Vec<String> = Vec::new();
 
-            for filter in opt.filters.iter() {
-                accept.append(&mut filter.extensions.to_vec());
+                for filter in dialog.filters.iter() {
+                    accept.append(&mut filter.extensions.to_vec());
+                }
+
+                accept.iter_mut().for_each(|ext| ext.insert_str(0, "."));
+
+                input.set_accept(&accept.join(","));
+
+                card.append_child(&input).unwrap();
+                HtmlIoElement::Input(input)
             }
+            FileKind::Out(dialog, data) => {
+                let output_el = document.create_element("a").unwrap();
+                let output: HtmlAnchorElement = wasm_bindgen::JsCast::dyn_into(output_el).unwrap();
 
-            accept.iter_mut().for_each(|ext| ext.insert_str(0, "."));
+                output.set_id("rfd-output");
+                output.set_inner_text("click here to download your file");
 
-            input.set_accept(&accept.join(","));
-
-            card.append_child(&input).unwrap();
-            input
+                card.append_child(&output).unwrap();
+                HtmlIoElement::Output {
+                    element: output,
+                    name: dialog.file_name.clone().unwrap_or_default(),
+                    data: data.clone(),
+                }
+            }
         };
 
         let button = {
@@ -87,7 +121,7 @@ impl WasmDialog {
             card,
             title,
             button,
-            input,
+            io,
 
             style,
         }
@@ -101,21 +135,74 @@ impl WasmDialog {
         let overlay = self.overlay.clone();
         let button = self.button.clone();
 
-        let promise = js_sys::Promise::new(&mut move |res, _rej| {
-            let closure = Closure::wrap(Box::new(move || {
-                res.call0(&JsValue::undefined()).unwrap();
-            }) as Box<dyn FnMut()>);
+        let promise = match &self.io {
+            HtmlIoElement::Input(_) => js_sys::Promise::new(&mut move |res, _rej| {
+                let resolve_promise = Closure::wrap(Box::new(move || {
+                    res.call0(&JsValue::undefined()).unwrap();
+                }) as Box<dyn FnMut()>);
 
-            button.set_onclick(Some(closure.as_ref().unchecked_ref()));
-            closure.forget();
-            body.append_child(&overlay).ok();
-        });
+                button.set_onclick(Some(resolve_promise.as_ref().unchecked_ref()));
+                resolve_promise.forget();
+                body.append_child(&overlay).ok();
+            }),
+            HtmlIoElement::Output {
+                element,
+                name,
+                data,
+            } => {
+                js_sys::Promise::new(&mut |res, _rej| {
+                    // Moved to keep closure as FnMut
+                    let output = element.clone();
+                    let file_name = name.clone();
+                    let data = data.clone();
+
+                    let resolve_promise = Closure::wrap(Box::new(move || {
+                        res.call1(&JsValue::undefined(), &JsValue::from(true))
+                            .unwrap();
+                    }) as Box<dyn FnMut()>);
+
+                    // Resolve the promise once the user clicks the download link or the button.
+                    output.set_onclick(Some(resolve_promise.as_ref().unchecked_ref()));
+                    button.set_onclick(Some(resolve_promise.as_ref().unchecked_ref()));
+                    resolve_promise.forget();
+
+                    let set_download_link = move |in_array: &[u8], name: &str| {
+                        // See <https://stackoverflow.com/questions/69556755/web-sysurlcreate-object-url-with-blobblob-not-formatting-binary-data-co>
+                        let array = js_sys::Array::new();
+                        let uint8arr = js_sys::Uint8Array::new(
+                            // Safety: No wasm allocations happen between creating the view and consuming it in the array.push
+                            &unsafe { js_sys::Uint8Array::view(&in_array) }.into(),
+                        );
+                        array.push(&uint8arr.buffer());
+                        let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(
+                            &array,
+                            web_sys::BlobPropertyBag::new().type_("application/octet-stream"),
+                        )
+                        .unwrap();
+                        let download_url =
+                            web_sys::Url::create_object_url_with_blob(&blob).unwrap();
+
+                        output.set_href(&download_url);
+                        output.set_download(&name);
+                    };
+
+                    set_download_link(&*data, &file_name);
+
+                    body.append_child(&overlay).ok();
+                })
+            }
+        };
+
         let future = wasm_bindgen_futures::JsFuture::from(promise);
         future.await.unwrap();
     }
 
     fn get_results(&self) -> Option<Vec<FileHandle>> {
-        if let Some(files) = self.input.files() {
+        let input = match &self.io {
+            HtmlIoElement::Input(input) => input,
+            _ => panic!("Internal Error: Results only exist for input dialog"),
+        };
+        if let Some(files) = input.files() {
             let len = files.length();
             if len > 0 {
                 let mut file_handles = Vec::new();
@@ -138,7 +225,11 @@ impl WasmDialog {
     }
 
     async fn pick_files(self) -> Option<Vec<FileHandle>> {
-        self.input.set_multiple(true);
+        if let HtmlIoElement::Input(input) = &self.io {
+            input.set_multiple(true);
+        } else {
+            panic!("Internal error: Pick files only on input wasm dialog")
+        }
 
         self.show().await;
 
@@ -146,18 +237,29 @@ impl WasmDialog {
     }
 
     async fn pick_file(self) -> Option<FileHandle> {
-        self.input.set_multiple(false);
+        if let HtmlIoElement::Input(input) = &self.io {
+            input.set_multiple(false);
+        } else {
+            panic!("Internal error: Pick file only on input wasm dialog")
+        }
 
         self.show().await;
 
         self.get_result()
+    }
+
+    fn io_element(&self) -> Element {
+        match self.io.clone() {
+            HtmlIoElement::Input(element) => element.unchecked_into(),
+            HtmlIoElement::Output { element, .. } => element.unchecked_into(),
+        }
     }
 }
 
 impl Drop for WasmDialog {
     fn drop(&mut self) {
         self.button.remove();
-        self.input.remove();
+        self.io_element().remove();
         self.title.as_ref().map(|elem| elem.remove());
         self.card.remove();
 
@@ -170,11 +272,11 @@ use super::{AsyncFilePickerDialogImpl, DialogFutureType};
 
 impl AsyncFilePickerDialogImpl for FileDialog {
     fn pick_file_async(self) -> DialogFutureType<Option<FileHandle>> {
-        let dialog = WasmDialog::new(&self);
+        let dialog = WasmDialog::new(&FileKind::In(self));
         Box::pin(dialog.pick_file())
     }
     fn pick_files_async(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
-        let dialog = WasmDialog::new(&self);
+        let dialog = WasmDialog::new(&FileKind::In(self));
         Box::pin(dialog.pick_files())
     }
 }
@@ -211,11 +313,20 @@ impl MessageDialogImpl for MessageDialog {
     }
 }
 
-use crate::backend::AsyncMessageDialogImpl;
-
-impl AsyncMessageDialogImpl for MessageDialog {
+impl crate::backend::AsyncMessageDialogImpl for MessageDialog {
     fn show_async(self) -> DialogFutureType<MessageDialogResult> {
         let val = MessageDialogImpl::show(self);
         Box::pin(std::future::ready(val))
+    }
+}
+
+impl FileHandle {
+    pub async fn write(&self, data: Box<[u8]>) {
+        let dialog = match &self.0 {
+            WasmFileHandleKind::Writable(dialog) => dialog,
+            _ => panic!("This File Handle doesn't support writing. Use `save_file` to get a writeable FileHandle in Wasm"),
+        };
+        let dialog = WasmDialog::new(&FileKind::Out(dialog.clone(), data));
+        dialog.show().await;
     }
 }

--- a/src/backend/wasm.rs
+++ b/src/backend/wasm.rs
@@ -96,7 +96,7 @@ impl WasmDialog {
     async fn show(&self) {
         let window = web_sys::window().expect("Window not found");
         let document = window.document().expect("Document not found");
-        let body = document.body().expect("document should have a body");
+        let body = document.body().expect("Document should have a body");
 
         let overlay = self.overlay.clone();
         let button = self.button.clone();

--- a/src/backend/wasm/file_dialog.rs
+++ b/src/backend/wasm/file_dialog.rs
@@ -1,0 +1,17 @@
+//
+// File Save
+//
+
+use crate::{
+    backend::{AsyncFileSaveDialogImpl, DialogFutureType},
+    file_dialog::FileDialog,
+    FileHandle,
+};
+use std::future::ready;
+impl AsyncFileSaveDialogImpl for FileDialog {
+    fn save_file_async(self) -> DialogFutureType<Option<FileHandle>> {
+        let file = FileHandle::default_with_name(&self.file_name.unwrap_or_default());
+
+        Box::pin(ready(Some(file)))
+    }
+}

--- a/src/backend/wasm/file_dialog.rs
+++ b/src/backend/wasm/file_dialog.rs
@@ -10,8 +10,7 @@ use crate::{
 use std::future::ready;
 impl AsyncFileSaveDialogImpl for FileDialog {
     fn save_file_async(self) -> DialogFutureType<Option<FileHandle>> {
-        let file = FileHandle::default_with_name(&self.file_name.unwrap_or_default());
-
+        let file = FileHandle::writable(self);
         Box::pin(ready(Some(file)))
     }
 }

--- a/src/backend/wasm/style.css
+++ b/src/backend/wasm/style.css
@@ -21,7 +21,7 @@
   box-shadow: 0 24px 38px 3px rgba(0, 0, 0, 0.14),
     0 9px 46px 8px rgba(0, 0, 0, 0.12), 0 11px 15px -7px rgba(0, 0, 0, 0.2);
 }
-#rfd-input {
+#rfd-input,#rfd-output {
   text-align: center;
 }
 #rfd-button {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -205,8 +205,9 @@ impl AsyncFileDialog {
 }
 
 use crate::backend::AsyncFilePickerDialogImpl;
+use crate::backend::AsyncFileSaveDialogImpl;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::backend::{AsyncFileSaveDialogImpl, AsyncFolderPickerDialogImpl};
+use crate::backend::AsyncFolderPickerDialogImpl;
 
 use std::future::Future;
 
@@ -237,11 +238,7 @@ impl AsyncFileDialog {
         AsyncFolderPickerDialogImpl::pick_folders_async(self.file_dialog)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     /// Opens save file dialog
-    ///
-    /// Does not exist in `WASM32`
-    ///
     ///
     /// #### Platform specific notes regarding save dialog filters:
     /// - On MacOs
@@ -256,6 +253,10 @@ impl AsyncFileDialog {
     ///     - If no extension was provided it will just add currently selected one
     ///     - If selected extension was typed in by the user it will just return
     ///     - If unselected extension was provided it will append selected one at the end, example: `test.png.txt`
+    /// - On Wasm32:
+    ///     - No filtering is applied.
+    ///     - `save_file` returns immediately without a dialog prompt.
+    /// Instead the user is prompted by their browser on where to save the file when [`FileHandle::write`] is used.
     pub fn save_file(self) -> impl Future<Output = Option<FileHandle>> {
         AsyncFileSaveDialogImpl::save_file_async(self.file_dialog)
     }

--- a/src/file_handle/mod.rs
+++ b/src/file_handle/mod.rs
@@ -14,6 +14,8 @@ pub use native::FileHandle;
 mod web;
 #[cfg(target_arch = "wasm32")]
 pub use web::FileHandle;
+#[cfg(target_arch = "wasm32")]
+pub(crate) use web::WasmFileHandleKind;
 
 #[cfg(test)]
 mod tests {

--- a/src/file_handle/native.rs
+++ b/src/file_handle/native.rs
@@ -118,7 +118,7 @@ impl FileHandle {
     /// On native platforms it wraps path.
     ///
     /// On `WASM32` it wraps JS `File` object.
-    pub fn wrap(path_buf: PathBuf) -> Self {
+    pub(crate) fn wrap(path_buf: PathBuf) -> Self {
         Self(path_buf)
     }
 

--- a/src/file_handle/native.rs
+++ b/src/file_handle/native.rs
@@ -88,12 +88,12 @@ impl FileHandle {
     ///
     /// On native platforms it spawns a `std::thread` in the background.
     ///
-    /// `This fn exists souly to keep native api in pair with async only web api.`
+    /// `This fn exists solely to keep native api in pair with async only web api.`
     pub async fn read(&self) -> Vec<u8> {
         Reader::new(&self.0).await
     }
 
-    /// Unwraps a `FileHandle` and returns innet type.
+    /// Unwraps a `FileHandle` and returns inner type.
     ///
     /// It should be used, if user wants to handle file read themselves
     ///

--- a/src/file_handle/native.rs
+++ b/src/file_handle/native.rs
@@ -47,8 +47,7 @@ impl Future for Reader {
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut state = self.state.lock().unwrap();
-        if state.res.is_some() {
-            let res = state.res.take().unwrap();
+        if let Some(res) = state.res.take() {
             Poll::Ready(res.unwrap())
         } else {
             state.waker.replace(ctx.waker().clone());
@@ -103,8 +102,7 @@ impl Future for Writer {
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut state = self.state.lock().unwrap();
-        if state.res.is_some() {
-            let res = state.res.take().unwrap();
+        if let Some(res) = state.res.take() {
             Poll::Ready(res)
         } else {
             state.waker.replace(ctx.waker().clone());

--- a/src/file_handle/web.rs
+++ b/src/file_handle/web.rs
@@ -59,7 +59,7 @@ impl FileHandle {
     pub async fn write(&self, data: Box<[u8]>) {
         let window = web_sys::window().expect("Window not found");
         let document = window.document().expect("Document not found");
-        let body = document.body().expect("document should have a body");
+        let body = document.body().expect("Document should have a body");
 
         let overlay = document.create_element("div").unwrap();
         overlay.set_id("rfd-overlay");

--- a/src/file_handle/web.rs
+++ b/src/file_handle/web.rs
@@ -1,24 +1,31 @@
+use crate::file_dialog::FileDialog;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys::{Blob, HtmlAnchorElement};
 
-pub struct FileHandle(web_sys::File);
+#[derive(Clone, Debug)]
+pub(crate) enum WasmFileHandleKind {
+    Readable(web_sys::File),
+    Writable(FileDialog),
+}
+
+pub struct FileHandle(pub(crate) WasmFileHandleKind);
 
 impl FileHandle {
+    /// Wrap a [`web_sys::File`] for reading. Use with [`FileHandle::read`]
     pub fn wrap(file: web_sys::File) -> Self {
-        Self(file)
+        Self(WasmFileHandleKind::Readable(file))
     }
 
-    /// Create a dummy file with a given name. Exists primarily for chaining with [`FileHandle::write`].
-    pub fn default_with_name(name: &str) -> Self {
-        FileHandle::wrap(
-            web_sys::File::new_with_u8_array_sequence(&js_sys::Array::default(), name)
-                .expect("Hardcoded file"),
-        )
+    /// Create a dummy `FileHandle`. Use with [`FileHandle::write`].
+    pub fn writable(dialog: FileDialog) -> Self {
+        FileHandle(WasmFileHandleKind::Writable(dialog))
     }
 
     pub fn file_name(&self) -> String {
-        self.0.name()
+        match &self.0 {
+            WasmFileHandleKind::Readable(x) => x.name(),
+            WasmFileHandleKind::Writable(x) => x.file_name.clone().unwrap_or_default(),
+        }
     }
 
     // Path is not supported in browsers.
@@ -42,7 +49,11 @@ impl FileHandle {
 
             closure.forget();
 
-            file_reader.read_as_array_buffer(&self.0).unwrap();
+            if let WasmFileHandleKind::Readable(reader) = &self.0 {
+                file_reader.read_as_array_buffer(reader).unwrap();
+            } else {
+                panic!("This File Handle doesn't support reading. Use `pick_file` to get a readable FileHandle");
+            }
         });
 
         let future = wasm_bindgen_futures::JsFuture::from(promise);
@@ -54,116 +65,6 @@ impl FileHandle {
         buffer.copy_to(&mut vec[..]);
 
         vec
-    }
-
-    pub async fn write(&self, data: Box<[u8]>) {
-        let window = web_sys::window().expect("Window not found");
-        let document = window.document().expect("Document not found");
-        let body = document.body().expect("Document should have a body");
-
-        let overlay = document.create_element("div").unwrap();
-        overlay.set_id("rfd-overlay");
-
-        let card = {
-            let card = document.create_element("div").unwrap();
-            card.set_id("rfd-card");
-            overlay.append_child(&card).unwrap();
-
-            card
-        };
-
-        /* // TODO move implementation to WasmDialog, create dialog here, and use title in dialog impl
-        let title = self.0..as_ref().map(|title| {
-            let title_el: web_sys::HtmlElement =
-                document.create_element("div").unwrap().dyn_into().unwrap();
-
-            title_el.set_id("rfd-title");
-            title_el.set_inner_html(title);
-
-            card.append_child(&title_el).unwrap();
-            title_el
-        }); */
-
-        let output = {
-            let output_el = document.create_element("a").unwrap();
-            let output: HtmlAnchorElement = wasm_bindgen::JsCast::dyn_into(output_el).unwrap();
-
-            output.set_id("rfd-output");
-            output.set_inner_text("click here to download your file");
-
-            card.append_child(&output).unwrap();
-            output
-        };
-
-        let button = {
-            let btn_el = document.create_element("button").unwrap();
-            let btn: web_sys::HtmlButtonElement = wasm_bindgen::JsCast::dyn_into(btn_el).unwrap();
-
-            btn.set_id("rfd-button");
-            btn.set_inner_text("Create file");
-
-            card.append_child(&btn).unwrap();
-            btn
-        };
-
-        let style = document.create_element("style").unwrap();
-        style.set_inner_html(include_str!("../backend/wasm/style.css"));
-        overlay.append_child(&style).unwrap();
-
-        body.append_child(&overlay).unwrap();
-
-        let promise = js_sys::Promise::new(&mut |res, _rej| {
-            // Moved to keep closure as FnMut
-            let output2 = output.clone();
-            let data = data.clone();
-            let file_name = self.file_name();
-
-            let set_download_link = move |in_array: &[u8], name: &str| {
-                // See <https://stackoverflow.com/questions/69556755/web-sysurlcreate-object-url-with-blobblob-not-formatting-binary-data-co>
-                let array = js_sys::Array::new();
-                let uint8arr = js_sys::Uint8Array::new(
-                    // Safety: No wasm allocations happen between creating the view and consuming it in the array.push
-                    &unsafe { js_sys::Uint8Array::view(&in_array) }.into(),
-                );
-                array.push(&uint8arr.buffer());
-                let blob = Blob::new_with_u8_array_sequence_and_options(
-                    &array,
-                    web_sys::BlobPropertyBag::new().type_("application/octet-stream"),
-                )
-                .unwrap();
-                let download_url = web_sys::Url::create_object_url_with_blob(&blob).unwrap();
-
-                output2.set_href(&download_url);
-                output2.set_download(&name);
-            };
-
-            let set_download_link = Closure::wrap(Box::new(move || {
-                set_download_link(&*data, &file_name);
-            }) as Box<dyn FnMut()>);
-
-            let end_promise = Closure::wrap(Box::new(move || {
-                res.call1(&JsValue::undefined(), &JsValue::from(true))
-                    .unwrap(); // End promise
-            }) as Box<dyn FnMut()>);
-
-            button.set_onclick(Some(set_download_link.as_ref().unchecked_ref()));
-            set_download_link.forget();
-
-            // Resolve the promise once the user clicks the download link.
-            output.set_onclick(Some(end_promise.as_ref().unchecked_ref()));
-            end_promise.forget();
-
-            body.append_child(&overlay).ok();
-        });
-        let future = wasm_bindgen_futures::JsFuture::from(promise);
-        future.await.unwrap();
-
-        // Drop impl
-        style.remove();
-        button.remove();
-        output.remove();
-        card.remove();
-        overlay.remove();
     }
 
     #[cfg(feature = "file-handle-inner")]

--- a/src/file_handle/web.rs
+++ b/src/file_handle/web.rs
@@ -9,6 +9,14 @@ impl FileHandle {
         Self(file)
     }
 
+    /// Create a dummy file with a given name. Exists primarily for chaining with [`FileHandle::write`].
+    pub fn default_with_name(name: &str) -> Self {
+        FileHandle::wrap(
+            web_sys::File::new_with_u8_array_sequence(&js_sys::Array::default(), name)
+                .expect("Hardcoded file"),
+        )
+    }
+
     pub fn file_name(&self) -> String {
         self.0.name()
     }
@@ -48,104 +56,114 @@ impl FileHandle {
         vec
     }
 
-    pub async fn write(data: Box<[u8]>) {
-        {
-            let window = web_sys::window().expect("Window not found");
-            let document = window.document().expect("Document not found");
-            let body = document.body().expect("document should have a body");
+    pub async fn write(&self, data: Box<[u8]>) {
+        let window = web_sys::window().expect("Window not found");
+        let document = window.document().expect("Document not found");
+        let body = document.body().expect("document should have a body");
 
-            let overlay = document.create_element("div").unwrap();
-            overlay.set_id("rfd-overlay");
+        let overlay = document.create_element("div").unwrap();
+        overlay.set_id("rfd-overlay");
 
-            let card = {
-                let card = document.create_element("div").unwrap();
-                card.set_id("rfd-card");
-                overlay.append_child(&card).unwrap();
+        let card = {
+            let card = document.create_element("div").unwrap();
+            card.set_id("rfd-card");
+            overlay.append_child(&card).unwrap();
 
-                card
+            card
+        };
+
+        /* // TODO move implementation to WasmDialog, create dialog here, and use title in dialog impl
+        let title = self.0..as_ref().map(|title| {
+            let title_el: web_sys::HtmlElement =
+                document.create_element("div").unwrap().dyn_into().unwrap();
+
+            title_el.set_id("rfd-title");
+            title_el.set_inner_html(title);
+
+            card.append_child(&title_el).unwrap();
+            title_el
+        }); */
+
+        let output = {
+            let output_el = document.create_element("a").unwrap();
+            let output: HtmlAnchorElement = wasm_bindgen::JsCast::dyn_into(output_el).unwrap();
+
+            output.set_id("rfd-output");
+            output.set_inner_text("click here to download your file");
+
+            card.append_child(&output).unwrap();
+            output
+        };
+
+        let button = {
+            let btn_el = document.create_element("button").unwrap();
+            let btn: web_sys::HtmlButtonElement = wasm_bindgen::JsCast::dyn_into(btn_el).unwrap();
+
+            btn.set_id("rfd-button");
+            btn.set_inner_text("Create file");
+
+            card.append_child(&btn).unwrap();
+            btn
+        };
+
+        let style = document.create_element("style").unwrap();
+        style.set_inner_html(include_str!("../backend/wasm/style.css"));
+        overlay.append_child(&style).unwrap();
+
+        body.append_child(&overlay).unwrap();
+
+        let promise = js_sys::Promise::new(&mut |res, _rej| {
+            // Moved to keep closure as FnMut
+            let output2 = output.clone();
+            let data = data.clone();
+            let file_name = self.file_name();
+
+            let set_download_link = move |in_array: &[u8], name: &str| {
+                // See <https://stackoverflow.com/questions/69556755/web-sysurlcreate-object-url-with-blobblob-not-formatting-binary-data-co>
+                let array = js_sys::Array::new();
+                let uint8arr = js_sys::Uint8Array::new(
+                    // Safety: No wasm allocations happen between creating the view and consuming it in the array.push
+                    &unsafe { js_sys::Uint8Array::view(&in_array) }.into(),
+                );
+                array.push(&uint8arr.buffer());
+                let blob = Blob::new_with_u8_array_sequence_and_options(
+                    &array,
+                    web_sys::BlobPropertyBag::new().type_("application/octet-stream"),
+                )
+                .unwrap();
+                let download_url = web_sys::Url::create_object_url_with_blob(&blob).unwrap();
+
+                output2.set_href(&download_url);
+                output2.set_download(&name);
             };
 
-            let output = {
-                let output_el = document.create_element("a").unwrap();
-                let output: HtmlAnchorElement = wasm_bindgen::JsCast::dyn_into(output_el).unwrap();
+            let set_download_link = Closure::wrap(Box::new(move || {
+                set_download_link(&*data, &file_name);
+            }) as Box<dyn FnMut()>);
 
-                output.set_id("rfd-output");
-                output.set_inner_text("click here to download your file");
+            let end_promise = Closure::wrap(Box::new(move || {
+                res.call1(&JsValue::undefined(), &JsValue::from(true))
+                    .unwrap(); // End promise
+            }) as Box<dyn FnMut()>);
 
-                card.append_child(&output).unwrap();
-                output
-            };
+            button.set_onclick(Some(set_download_link.as_ref().unchecked_ref()));
+            set_download_link.forget();
 
-            let button = {
-                let btn_el = document.create_element("button").unwrap();
-                let btn: web_sys::HtmlButtonElement =
-                    wasm_bindgen::JsCast::dyn_into(btn_el).unwrap();
+            // Resolve the promise once the user clicks the download link.
+            output.set_onclick(Some(end_promise.as_ref().unchecked_ref()));
+            end_promise.forget();
 
-                btn.set_id("rfd-button");
-                btn.set_inner_text("Create file");
+            body.append_child(&overlay).ok();
+        });
+        let future = wasm_bindgen_futures::JsFuture::from(promise);
+        future.await.unwrap();
 
-                card.append_child(&btn).unwrap();
-                btn
-            };
-
-            let style = document.create_element("style").unwrap();
-            style.set_inner_html(include_str!("../backend/wasm/style.css"));
-            overlay.append_child(&style).unwrap();
-
-            body.append_child(&overlay).unwrap();
-
-            let promise = js_sys::Promise::new(&mut |res, _rej| {
-                // Clones to keep closure as FnMut
-                let output2 = output.clone();
-                let data = data.clone();
-
-                let set_download_link = move |in_array: &[u8], name: &str| {
-                    // See <https://stackoverflow.com/questions/69556755/web-sysurlcreate-object-url-with-blobblob-not-formatting-binary-data-co>
-                    let array = js_sys::Array::new();
-                    let uint8arr = js_sys::Uint8Array::new(
-                        // Safety: No wasm allocations happen between creating the view and consuming it in the array.push
-                        &unsafe { js_sys::Uint8Array::view(&in_array) }.into(),
-                    );
-                    array.push(&uint8arr.buffer());
-                    let blob = Blob::new_with_u8_array_sequence_and_options(
-                        &array,
-                        web_sys::BlobPropertyBag::new().type_("application/octet-stream"),
-                    )
-                    .unwrap();
-                    let download_url = web_sys::Url::create_object_url_with_blob(&blob).unwrap();
-
-                    output2.set_href(&download_url);
-                    output2.set_download(&name);
-                };
-
-                let set_download_link = Closure::wrap(Box::new(move || {
-                    set_download_link(&*data, "file.txt");
-                }) as Box<dyn FnMut()>);
-
-                let end_promise = Closure::wrap(Box::new(move || {
-                    res.call1(&JsValue::undefined(), &JsValue::from(true))
-                        .unwrap(); // End promise
-                }) as Box<dyn FnMut()>);
-
-                button.set_onclick(Some(set_download_link.as_ref().unchecked_ref()));
-                set_download_link.forget();
-
-                // Resolve the promise once the user clicks the download link.
-                output.set_onclick(Some(end_promise.as_ref().unchecked_ref()));
-                end_promise.forget();
-
-                body.append_child(&overlay).ok();
-            });
-            let future = wasm_bindgen_futures::JsFuture::from(promise);
-            future.await.unwrap();
-
-            // Drop impl
-            style.remove();
-            button.remove();
-            output.remove();
-            card.remove();
-            overlay.remove();
-        }
+        // Drop impl
+        style.remove();
+        button.remove();
+        output.remove();
+        card.remove();
+        overlay.remove();
     }
 
     #[cfg(feature = "file-handle-inner")]

--- a/src/file_handle/web.rs
+++ b/src/file_handle/web.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+use web_sys::{Blob, HtmlAnchorElement};
 
 pub struct FileHandle(web_sys::File);
 
@@ -45,6 +46,106 @@ impl FileHandle {
         buffer.copy_to(&mut vec[..]);
 
         vec
+    }
+
+    pub async fn write(data: Box<[u8]>) {
+        {
+            let window = web_sys::window().expect("Window not found");
+            let document = window.document().expect("Document not found");
+            let body = document.body().expect("document should have a body");
+
+            let overlay = document.create_element("div").unwrap();
+            overlay.set_id("rfd-overlay");
+
+            let card = {
+                let card = document.create_element("div").unwrap();
+                card.set_id("rfd-card");
+                overlay.append_child(&card).unwrap();
+
+                card
+            };
+
+            let output = {
+                let output_el = document.create_element("a").unwrap();
+                let output: HtmlAnchorElement = wasm_bindgen::JsCast::dyn_into(output_el).unwrap();
+
+                output.set_id("rfd-output");
+                output.set_inner_text("click here to download your file");
+
+                card.append_child(&output).unwrap();
+                output
+            };
+
+            let button = {
+                let btn_el = document.create_element("button").unwrap();
+                let btn: web_sys::HtmlButtonElement =
+                    wasm_bindgen::JsCast::dyn_into(btn_el).unwrap();
+
+                btn.set_id("rfd-button");
+                btn.set_inner_text("Create file");
+
+                card.append_child(&btn).unwrap();
+                btn
+            };
+
+            let style = document.create_element("style").unwrap();
+            style.set_inner_html(include_str!("../backend/wasm/style.css"));
+            overlay.append_child(&style).unwrap();
+
+            body.append_child(&overlay).unwrap();
+
+            let promise = js_sys::Promise::new(&mut |res, _rej| {
+                // Clones to keep closure as FnMut
+                let output2 = output.clone();
+                let data = data.clone();
+
+                let set_download_link = move |in_array: &[u8], name: &str| {
+                    // See <https://stackoverflow.com/questions/69556755/web-sysurlcreate-object-url-with-blobblob-not-formatting-binary-data-co>
+                    let array = js_sys::Array::new();
+                    let uint8arr = js_sys::Uint8Array::new(
+                        // Safety: No wasm allocations happen between creating the view and consuming it in the array.push
+                        &unsafe { js_sys::Uint8Array::view(&in_array) }.into(),
+                    );
+                    array.push(&uint8arr.buffer());
+                    let blob = Blob::new_with_u8_array_sequence_and_options(
+                        &array,
+                        web_sys::BlobPropertyBag::new().type_("application/octet-stream"),
+                    )
+                    .unwrap();
+                    let download_url = web_sys::Url::create_object_url_with_blob(&blob).unwrap();
+
+                    output2.set_href(&download_url);
+                    output2.set_download(&name);
+                };
+
+                let set_download_link = Closure::wrap(Box::new(move || {
+                    set_download_link(&*data, "file.txt");
+                }) as Box<dyn FnMut()>);
+
+                let end_promise = Closure::wrap(Box::new(move || {
+                    res.call1(&JsValue::undefined(), &JsValue::from(true))
+                        .unwrap(); // End promise
+                }) as Box<dyn FnMut()>);
+
+                button.set_onclick(Some(set_download_link.as_ref().unchecked_ref()));
+                set_download_link.forget();
+
+                // Resolve the promise once the user clicks the download link.
+                output.set_onclick(Some(end_promise.as_ref().unchecked_ref()));
+                end_promise.forget();
+
+                body.append_child(&overlay).ok();
+            });
+            let future = wasm_bindgen_futures::JsFuture::from(promise);
+            future.await.unwrap();
+
+            // Drop impl
+            style.remove();
+            button.remove();
+            output.remove();
+            card.remove();
+            overlay.remove();
+        }
     }
 
     #[cfg(feature = "file-handle-inner")]

--- a/src/file_handle/web.rs
+++ b/src/file_handle/web.rs
@@ -12,12 +12,12 @@ pub struct FileHandle(pub(crate) WasmFileHandleKind);
 
 impl FileHandle {
     /// Wrap a [`web_sys::File`] for reading. Use with [`FileHandle::read`]
-    pub fn wrap(file: web_sys::File) -> Self {
+    pub(crate) fn wrap(file: web_sys::File) -> Self {
         Self(WasmFileHandleKind::Readable(file))
     }
 
     /// Create a dummy `FileHandle`. Use with [`FileHandle::write`].
-    pub fn writable(dialog: FileDialog) -> Self {
+    pub(crate) fn writable(dialog: FileDialog) -> Self {
         FileHandle(WasmFileHandleKind::Writable(dialog))
     }
 


### PR DESCRIPTION
Solving https://github.com/PolyMeilex/rfd/issues/88.

Create new `rfd::FileHandle::write(data: Box<[u8]>)` which should be able to be implemented for all targets including Wasm.

Currently only implemented for Wasm target and everything is in one function. It should almost certainly be be moved out to `WasmDialog`

I won't bother finishing this if it's indicated that this is an unwanted way to solve the issue, so feedback is welcome.

The other solution indicated appears to be
>There is also a chrome specific API that lets you open a file save dialog and get a file handle that way, this aligns with how paths work on native so we would just have to wrap those in a new type.

but that sounds like it won't work on Firefox.