### PR TITLE
Fix GTK async dialog using 100% cpu

### DIFF
--- a/src/backend/gtk3/utils.rs
+++ b/src/backend/gtk3/utils.rs
@@ -97,13 +97,11 @@ impl GtkThread {
         let _handle = {
             let running = running.clone();
             std::thread::spawn(move || {
-                while running.load(Ordering::Acquire) {
-                    GTK_MUTEX.run_locked(|| unsafe {
-                        while gtk_sys::gtk_events_pending() == 1 {
-                            gtk_sys::gtk_main_iteration();
-                        }
-                    });
-                }
+                GTK_MUTEX.run_locked(|| unsafe {
+                    while running.load(Ordering::Acquire) {
+                        gtk_sys::gtk_main_iteration();
+                    }
+                });
             })
         };
 


### PR DESCRIPTION
Resolves #150

If `gtk_events_pending()` returns 0, this loop would spin until `gtk_events_pending()` returned 1.

Now, we just run the (blocking) `gtk_main_iteration` in an unconditional loop (it unblocks once the dialog closes) which properly yields the thread.