### PR TITLE
Run all GTK dialogs on one thread

### DIFF
--- a/src/backend/gtk3/file_dialog.rs
+++ b/src/backend/gtk3/file_dialog.rs
@@ -4,7 +4,7 @@ use dialog_ffi::GtkFileDialog;
 
 use std::path::PathBuf;
 
-use super::utils::{gtk_init_check, GTK_MUTEX};
+use super::utils::GtkGlobalThread;
 use crate::backend::DialogFutureType;
 use crate::{FileDialog, FileHandle};
 
@@ -17,11 +17,7 @@ use super::gtk_future::GtkDialogFuture;
 use crate::backend::FilePickerDialogImpl;
 impl FilePickerDialogImpl for FileDialog {
     fn pick_file(self) -> Option<PathBuf> {
-        GTK_MUTEX.run_locked(|| {
-            if !gtk_init_check() {
-                return None;
-            };
-
+        GtkGlobalThread::instance().run_blocking(move || {
             let dialog = GtkFileDialog::build_pick_file(&self);
 
             if dialog.run() == gtk_sys::GTK_RESPONSE_ACCEPT {
@@ -33,11 +29,7 @@ impl FilePickerDialogImpl for FileDialog {
     }
 
     fn pick_files(self) -> Option<Vec<PathBuf>> {
-        GTK_MUTEX.run_locked(|| {
-            if !gtk_init_check() {
-                return None;
-            };
-
+        GtkGlobalThread::instance().run_blocking(move || {
             let dialog = GtkFileDialog::build_pick_files(&self);
 
             if dialog.run() == gtk_sys::GTK_RESPONSE_ACCEPT {
@@ -93,11 +85,7 @@ impl AsyncFilePickerDialogImpl for FileDialog {
 use crate::backend::FolderPickerDialogImpl;
 impl FolderPickerDialogImpl for FileDialog {
     fn pick_folder(self) -> Option<PathBuf> {
-        GTK_MUTEX.run_locked(|| {
-            if !gtk_init_check() {
-                return None;
-            };
-
+        GtkGlobalThread::instance().run_blocking(move || {
             let dialog = GtkFileDialog::build_pick_folder(&self);
 
             if dialog.run() == gtk_sys::GTK_RESPONSE_ACCEPT {
@@ -109,11 +97,7 @@ impl FolderPickerDialogImpl for FileDialog {
     }
 
     fn pick_folders(self) -> Option<Vec<PathBuf>> {
-        GTK_MUTEX.run_locked(|| {
-            if !gtk_init_check() {
-                return None;
-            };
-
+        GtkGlobalThread::instance().run_blocking(move || {
             let dialog = GtkFileDialog::build_pick_folders(&self);
 
             if dialog.run() == gtk_sys::GTK_RESPONSE_ACCEPT {
@@ -169,11 +153,7 @@ impl AsyncFolderPickerDialogImpl for FileDialog {
 use crate::backend::FileSaveDialogImpl;
 impl FileSaveDialogImpl for FileDialog {
     fn save_file(self) -> Option<PathBuf> {
-        GTK_MUTEX.run_locked(|| {
-            if !gtk_init_check() {
-                return None;
-            };
-
+        GtkGlobalThread::instance().run_blocking(move || {
             let dialog = GtkFileDialog::build_save_file(&self);
 
             if dialog.run() == gtk_sys::GTK_RESPONSE_ACCEPT {

--- a/src/backend/gtk3/file_dialog/dialog_ffi.rs
+++ b/src/backend/gtk3/file_dialog/dialog_ffi.rs
@@ -291,9 +291,7 @@ impl AsGtkDialog for GtkFileDialog {
 impl Drop for GtkFileDialog {
     fn drop(&mut self) {
         unsafe {
-            super::super::utils::wait_for_cleanup();
             gtk_sys::gtk_native_dialog_destroy(self.ptr as _);
-            super::super::utils::wait_for_cleanup();
         }
     }
 }


### PR DESCRIPTION
When investigating #150 more deeply, I noticed that the GTK documentation seems to indicate that all GTK functions must only be called on the thread that called gtk_init(). The existing code does ensure that only one thread accesses GTK *at a time*, but the documentation seems to suggest that once a thread calls gtk_init, all calls to GTK *must* go through that thread:

> ["GTK+, however, is not thread safe. You should only use GTK+ and GDK from the thread gtk_init() and gtk_main() were called on. This is usually referred to as the "main thread"."](https://developer-old.gnome.org/gdk3/unstable/gdk3-Threads.html)

To facilitate that, this PR changes the GTK dialog code to spin up a thread and initialize GTK on it, keeping it alive for the lifetime of the program. It's a bit unfortunate that we have to keep it around forever, but the GTK documentation seems to indicate that once you call gtk_init on a thread, you're stuck with that thread.