### PR TITLE
Fix `file-handle-inner` on wasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+- Fix `FileHandle::inner` (under feature `file-handle-inner`) on wasm
+
 ## 0.12.0
 - Add title support for WASM (#132) 
 - Add Create folder button to `pick_folder` on macOS (#127)

--- a/src/file_handle/web.rs
+++ b/src/file_handle/web.rs
@@ -69,7 +69,11 @@ impl FileHandle {
 
     #[cfg(feature = "file-handle-inner")]
     pub fn inner(&self) -> &web_sys::File {
-        &self.0
+        if let WasmFileHandleKind::Readable(reader) = &self.0 {
+            reader
+        } else {
+            panic!("This File Handle doesn't support reading. Use `pick_file` to get a readable FileHandle");
+        }
     }
 }
 


### PR DESCRIPTION
`rfd` v0.12 broke the `FileHandle::inner`