### PR TITLE
Make Zenity backend optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ documentation = "https://docs.rs/rfd"
 default = ["gtk3"]
 file-handle-inner = []
 gtk3 = ["gtk-sys", "glib-sys", "gobject-sys"]
-xdg-portal = ["ashpd", "urlencoding", "pollster", "async-io", "futures-util"]
+xdg-portal = ["ashpd", "urlencoding", "pollster"]
+# Enables message dialogs on Linux when gtk3 is disabled and the end
+# user has zenity installed
+zenity = ["async-io", "futures-util"]
 common-controls-v6 = ["windows-sys/Win32_UI_Controls"]
 
 [dev-dependencies]

--- a/src/backend/linux/mod.rs
+++ b/src/backend/linux/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "zenity")]
 mod child_stdout;
+#[cfg(feature = "zenity")]
 pub(crate) mod zenity;

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -2,8 +2,11 @@ use std::path::PathBuf;
 
 use crate::backend::DialogFutureType;
 use crate::file_dialog::Filter;
+#[cfg(feature = "zenity")]
 use crate::message_dialog::MessageDialog;
-use crate::{FileDialog, FileHandle, MessageButtons, MessageDialogResult};
+use crate::{FileDialog, FileHandle};
+#[cfg(feature = "zenity")]
+use crate::{MessageButtons, MessageDialogResult};
 
 use ashpd::desktop::file_chooser::{FileFilter, OpenFileRequest, SaveFileRequest};
 // TODO: convert raw_window_handle::RawWindowHandle to ashpd::WindowIdentifier
@@ -192,14 +195,18 @@ impl AsyncFileSaveDialogImpl for FileDialog {
     }
 }
 
+#[cfg(feature = "zenity")]
 use crate::backend::MessageDialogImpl;
+#[cfg(feature = "zenity")]
 impl MessageDialogImpl for MessageDialog {
     fn show(self) -> MessageDialogResult {
         block_on(self.show_async())
     }
 }
 
+#[cfg(feature = "zenity")]
 use crate::backend::AsyncMessageDialogImpl;
+#[cfg(feature = "zenity")]
 impl AsyncMessageDialogImpl for MessageDialog {
     fn show_async(self) -> DialogFutureType<MessageDialogResult> {
         Box::pin(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,9 @@
 //! they can all be installed simultaneously).
 //!
 //! The XDG Desktop Portal has no API for message dialogs, so the [MessageDialog] and
-//! [AsyncMessageDialog] structs will not build with this backend.
+//! [AsyncMessageDialog] structs will not build with this backend unless the `zenity` feature is
+//! enabled. However, `zenity`-based dialogs will silently fail if the end user does not have the
+//! `zenity` binary in `$PATH`.
 //!
 //! # macOS non-windowed applications, async, and threading
 //!

--- a/src/message_dialog.rs
+++ b/src/message_dialog.rs
@@ -1,7 +1,10 @@
+#[cfg(any(not(target_os = "linux"), feature = "zenity"))]
 use crate::backend::AsyncMessageDialogImpl;
+#[cfg(any(not(target_os = "linux"), feature = "zenity"))]
 use crate::backend::MessageDialogImpl;
 use std::fmt::{Display, Formatter};
 
+#[cfg(any(not(target_os = "linux"), feature = "zenity"))]
 use std::future::Future;
 
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
@@ -9,7 +12,7 @@ use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 /// Synchronous Message Dialog. Supported platforms:
 ///  * Windows
 ///  * macOS
-///  * Linux (GTK only)
+///  * Linux (GTK or Zenity only)
 ///  * WASM
 #[derive(Default, Debug, Clone)]
 pub struct MessageDialog {
@@ -71,6 +74,7 @@ impl MessageDialog {
     }
 
     /// Shows a message dialog and returns the button that was pressed.
+    #[cfg(any(not(target_os = "linux"), any(feature = "zenity", feature = "gtk3")))]
     pub fn show(self) -> MessageDialogResult {
         MessageDialogImpl::show(self)
     }
@@ -79,7 +83,7 @@ impl MessageDialog {
 /// Asynchronous Message Dialog. Supported platforms:
 ///  * Windows
 ///  * macOS
-///  * Linux (GTK only)
+///  * Linux (GTK or Zenity only)
 ///  * WASM
 #[derive(Default, Debug, Clone)]
 pub struct AsyncMessageDialog(MessageDialog);
@@ -131,6 +135,7 @@ impl AsyncMessageDialog {
     }
 
     /// Shows a message dialog and returns the button that was pressed.
+    #[cfg(any(not(target_os = "linux"), any(feature = "zenity", feature = "gtk3")))]
     pub fn show(self) -> impl Future<Output = MessageDialogResult> {
         AsyncMessageDialogImpl::show_async(self.0)
     }


### PR DESCRIPTION
Saves some Rust dependencies for users who are willing to require gtk3 (the default) or who don't want message dialogs at all.