### PR TITLE
[macOS] Use NSOpenPanel.message instead of title

### DIFF
--- a/src/backend/macos/file_dialog/panel_ffi.rs
+++ b/src/backend/macos/file_dialog/panel_ffi.rs
@@ -126,7 +126,7 @@ impl Panel {
     pub fn set_title(&self, title: &str) {
         unsafe {
             let title = make_nsstring(title);
-            let () = msg_send![self.panel, setTitle: title];
+            let () = msg_send![self.panel, setMessage: title];
         }
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -79,7 +79,7 @@ impl FileDialog {
     /// Set the title of the dialog. Supported platforms:
     ///  * Windows
     ///  * Linux
-    ///  * Mac (Only below version 10.11)
+    ///  * Mac
     pub fn set_title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
@@ -189,7 +189,7 @@ impl AsyncFileDialog {
     /// Set the title of the dialog. Supported platforms:
     ///  * Windows
     ///  * Linux
-    ///  * Mac (Only below version 10.11)
+    ///  * Mac
     ///  * WASM32
     pub fn set_title(mut self, title: impl Into<String>) -> Self {
         self.file_dialog = self.file_dialog.set_title(title);


### PR DESCRIPTION
Open panels do not have a title bar on modern macOS, so set the 'message' property instead:
https://developer.apple.com/documentation/appkit/nssavepanel/1528581-message

This makes the `set_title` functions work as expected:

<img width="912" alt="Screenshot 2023-12-22 at 8 42 20 PM" src="https://github.com/PolyMeilex/rfd/assets/19418817/86a94d5b-b0e7-4e36-9b2c-333e2fa25815">
