### PR TITLE
Properly support setting the parent window for the sync macOS backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Update `raw-window-handle` to 0.6.
 - Update `winit` in example to 0.29.
 - Update wasm CSS to respect the color scheme (including dark mode)
+- Fix macOS sync backend incorrectly setting the parent window
 
 ## 0.13.0
 - **[Breaking]** Users of the `xdg-portal` feature must now also select the `tokio`


### PR DESCRIPTION
This will properly show the sheets as children of the parent window.