### PR TITLE
Implement `FileDialog.starting_directory` for xdg desktop portal backend

### DIFF
--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -47,6 +47,8 @@ impl AsyncFilePickerDialogImpl for FileDialog {
                 .multiple(false)
                 .title(self.title.as_deref().or(None))
                 .filters(self.filters.iter().map(From::from))
+                .current_folder::<&PathBuf>(&self.starting_directory)
+                .expect("File path should not be nul-terminated")
                 .send()
                 .await;
 
@@ -78,6 +80,8 @@ impl AsyncFilePickerDialogImpl for FileDialog {
                 .multiple(true)
                 .title(self.title.as_deref().or(None))
                 .filters(self.filters.iter().map(From::from))
+                .current_folder::<&PathBuf>(&self.starting_directory)
+                .expect("File path should not be nul-terminated")
                 .send()
                 .await;
 
@@ -130,6 +134,8 @@ impl AsyncFolderPickerDialogImpl for FileDialog {
                 .directory(true)
                 .title(self.title.as_deref().or(None))
                 .filters(self.filters.iter().map(From::from))
+                .current_folder::<&PathBuf>(dbg!(&self.starting_directory))
+                .expect("File path should not be nul-terminated")
                 .send()
                 .await;
 
@@ -162,6 +168,8 @@ impl AsyncFolderPickerDialogImpl for FileDialog {
                 .directory(true)
                 .title(self.title.as_deref().or(None))
                 .filters(self.filters.iter().map(From::from))
+                .current_folder::<&PathBuf>(&self.starting_directory)
+                .expect("File path should not be nul-terminated")
                 .send()
                 .await;
 

--- a/src/backend/xdg_desktop_portal.rs
+++ b/src/backend/xdg_desktop_portal.rs
@@ -134,7 +134,7 @@ impl AsyncFolderPickerDialogImpl for FileDialog {
                 .directory(true)
                 .title(self.title.as_deref().or(None))
                 .filters(self.filters.iter().map(From::from))
-                .current_folder::<&PathBuf>(dbg!(&self.starting_directory))
+                .current_folder::<&PathBuf>(&self.starting_directory)
                 .expect("File path should not be nul-terminated")
                 .send()
                 .await;


### PR DESCRIPTION
Implements `FileDialog.starting_directory` for the xdg desktop portal backend using [`ashpd::OpenFileRequest::current_folder`](https://docs.rs/ashpd/latest/ashpd/desktop/file_chooser/struct.OpenFileRequest.html#method.current_folder)

Fixes #42