### PR TITLE
Avoid unnecessary heap allocation and copy

### DIFF
--- a/src/file_handle/native.rs
+++ b/src/file_handle/native.rs
@@ -183,7 +183,7 @@ impl From<PathBuf> for FileHandle {
 
 impl From<FileHandle> for PathBuf {
     fn from(file_handle: FileHandle) -> Self {
-        PathBuf::from(file_handle.path())
+        file_handle.0
     }
 }
 


### PR DESCRIPTION
Looks like the current implementation of `From<FileHandle> for PathBuf` passes a `Path` reference to the `PathBuf::from` which results in a new heap allocation from a call to `to_os_string()` down the call-stack.

Since `From<FileHandle>` consumes the `FileHandle` it seems reasonable to consume the member `PathBuf` and return it to the caller without any copies or allocations.