### PR TITLE
`Send`/`Sync` `DialogFutureType`

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -76,7 +76,7 @@ pub trait MessageDialogImpl {
 
 // Return type of async dialogs:
 #[cfg(not(target_arch = "wasm32"))]
-pub type DialogFutureType<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+pub type DialogFutureType<T> = Pin<Box<dyn Future<Output = T> + Send + Sync>>;
 #[cfg(target_arch = "wasm32")]
 pub type DialogFutureType<T> = Pin<Box<dyn Future<Output = T>>>;
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -227,8 +227,6 @@ use crate::backend::AsyncFileSaveDialogImpl;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::backend::AsyncFolderPickerDialogImpl;
 
-use std::future::Future;
-
 impl AsyncFileDialog {
     /// Pick one file
     pub fn pick_file(self) -> DialogFutureType<Option<FileHandle>> {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1,3 +1,4 @@
+use crate::backend::DialogFutureType;
 use crate::FileHandle;
 
 use std::path::Path;
@@ -230,12 +231,12 @@ use std::future::Future;
 
 impl AsyncFileDialog {
     /// Pick one file
-    pub fn pick_file(self) -> impl Future<Output = Option<FileHandle>> {
+    pub fn pick_file(self) -> DialogFutureType<Option<FileHandle>> {
         AsyncFilePickerDialogImpl::pick_file_async(self.file_dialog)
     }
 
     /// Pick multiple files
-    pub fn pick_files(self) -> impl Future<Output = Option<Vec<FileHandle>>> {
+    pub fn pick_files(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
         AsyncFilePickerDialogImpl::pick_files_async(self.file_dialog)
     }
 
@@ -243,7 +244,7 @@ impl AsyncFileDialog {
     /// Pick one folder
     ///
     /// Does not exist in `WASM32`
-    pub fn pick_folder(self) -> impl Future<Output = Option<FileHandle>> {
+    pub fn pick_folder(self) -> DialogFutureType<Option<FileHandle>> {
         AsyncFolderPickerDialogImpl::pick_folder_async(self.file_dialog)
     }
 
@@ -251,7 +252,7 @@ impl AsyncFileDialog {
     /// Pick multiple folders
     ///
     /// Does not exist in `WASM32`
-    pub fn pick_folders(self) -> impl Future<Output = Option<Vec<FileHandle>>> {
+    pub fn pick_folders(self) -> DialogFutureType<Option<Vec<FileHandle>>> {
         AsyncFolderPickerDialogImpl::pick_folders_async(self.file_dialog)
     }
 
@@ -274,7 +275,7 @@ impl AsyncFileDialog {
     ///     - No filtering is applied.
     ///     - `save_file` returns immediately without a dialog prompt.
     /// Instead the user is prompted by their browser on where to save the file when [`FileHandle::write`] is used.
-    pub fn save_file(self) -> impl Future<Output = Option<FileHandle>> {
+    pub fn save_file(self) -> DialogFutureType<Option<FileHandle>> {
         AsyncFileSaveDialogImpl::save_file_async(self.file_dialog)
     }
 }


### PR DESCRIPTION
Trying to use async `save_file` and co. in a context that requires my futures to be `Send` and `Sync` and getting errors. Turns out the `Future` returned by `save_file` is already `Send`, but the signature of `save_file` only guarantees `impl Future<...>`. We can get the `Send` guarantee for free by specifying a specific type for the future returned by `save_file` (and I did the others for consistency).

The change I'm less certain on is adding `Sync` to `DialogFutureType`'s inner boxed type. It all builds, so I don't think there's a problem with that (haven't tested on wasm) and I don't even think anything I did is a breaking change. If you have a suite of tests to put this through, though, that probably wouldn't be a bad idea.

PS Just looked and I don't think anything I did should affect wasm since `DialogFutureType` isn't `Send` on wasm, and I didn't add any trait bounds for that config. So unless I'm way more tired than I'm realizing, this PR shouldn't break anything! 🎉