### PR TITLE
Add `TDF_SIZE_TO_CONTENT` to Windows message dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 - Move from `objc` crates to `objc2` crates.
 - Fix `AsyncFileDialog` blocking the executor on Windows (#191)
-- Add `TDF_SIZE_TO_CONTENT` to `TaskDialogIndirect` config so that it can display long text without truncating/wrapping
+- Add `TDF_SIZE_TO_CONTENT` to `TaskDialogIndirect` config so that it can display longer text without truncating/wrapping (80 characters instead of 55) (#202)
 
 ## 0.14.0
 - i18n for GTK and XDG Portal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Move from `objc` crates to `objc2` crates.
 - Fix `AsyncFileDialog` blocking the executor on Windows (#191)
+- Add `TDF_SIZE_TO_CONTENT` to `TaskDialogIndirect` config so that it can display long text without truncating/wrapping
 
 ## 0.14.0
 - i18n for GTK and XDG Portal

--- a/src/backend/win_cid/message_dialog.rs
+++ b/src/backend/win_cid/message_dialog.rs
@@ -75,8 +75,8 @@ impl WinMessageDialog {
             UI::Controls::{
                 TaskDialogIndirect, TASKDIALOGCONFIG, TASKDIALOGCONFIG_0, TASKDIALOGCONFIG_1,
                 TASKDIALOG_BUTTON, TDCBF_CANCEL_BUTTON, TDCBF_NO_BUTTON, TDCBF_OK_BUTTON,
-                TDCBF_YES_BUTTON, TDF_ALLOW_DIALOG_CANCELLATION, TD_ERROR_ICON,
-                TD_INFORMATION_ICON, TD_WARNING_ICON,
+                TDCBF_YES_BUTTON, TDF_ALLOW_DIALOG_CANCELLATION, TDF_SIZE_TO_CONTENT,
+                TD_ERROR_ICON, TD_INFORMATION_ICON, TD_WARNING_ICON,
             },
         };
 
@@ -135,7 +135,7 @@ impl WinMessageDialog {
         let task_dialog_config = TASKDIALOGCONFIG {
             cbSize: core::mem::size_of::<TASKDIALOGCONFIG>() as u32,
             hwndParent: self.parent.unwrap_or_default(),
-            dwFlags: TDF_ALLOW_DIALOG_CANCELLATION,
+            dwFlags: TDF_ALLOW_DIALOG_CANCELLATION | TDF_SIZE_TO_CONTENT,
             pszWindowTitle: self.caption.as_ptr(),
             pszContent: self.text.as_ptr(),
             Anonymous1: TASKDIALOGCONFIG_0 {


### PR DESCRIPTION
Add `TDF_SIZE_TO_CONTENT` to `TaskDialogIndirect` config so that it can display long text without truncating/wrapping (will still do if too long but can display way more characters, 80 instead of 55 I believe)

Before:

![image](https://github.com/PolyMeilex/rfd/assets/68118705/ae732165-98a1-4f42-b762-c53ad74bea92)

After:

![image](https://github.com/PolyMeilex/rfd/assets/68118705/31de2387-8362-45df-9088-32c112a1829c)
