### PR TITLE
Pass `--no-markup` to zenity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Move from `objc` crates to `objc2` crates.
 - Fix `AsyncFileDialog` blocking the executor on Windows (#191)
 - Add `TDF_SIZE_TO_CONTENT` to `TaskDialogIndirect` config so that it can display longer text without truncating/wrapping (80 characters instead of 55) (#202)
+- Fix `xdg-portal` backend not accepting special characters in message dialogs
 
 ## 0.14.0
 - i18n for GTK and XDG Portal

--- a/src/backend/linux/zenity.rs
+++ b/src/backend/linux/zenity.rs
@@ -38,7 +38,9 @@ impl From<std::string::FromUtf8Error> for ZenityError {
 pub type ZenityResult<T> = Result<T, ZenityError>;
 
 fn command() -> Command {
-    Command::new("zenity")
+    let mut cmd = Command::new("zenity");
+    cmd.arg("--no-markup");
+    cmd
 }
 
 fn add_filters(command: &mut Command, filters: &[Filter]) {


### PR DESCRIPTION
zenity will replace any dialog text that contains the characters `<` or `>` with a generic error message, because it tries to interpret those characters as pango markup.

This patch should prevent that from happening.