### PR TITLE
Add support for `set_parent` in XDG portals

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,9 +41,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - name: "[Ubuntu] install dependencies"
+    - name: "[Ubuntu GTK] install dependencies"
       if: matrix.name == 'Ubuntu GTK'
       run: sudo apt update && sudo apt install libgtk-3-dev
+    - name: "[Ubuntu XDG] install dependencies"
+      if: matrix.name == 'Ubuntu XDG'
+      run: sudo apt update && sudo apt install libwayland-dev
     - name: "[WASM] rustup"
       if: matrix.name == 'WASM32'
       run: rustup target add wasm32-unknown-unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `AsyncFileDialog` blocking the executor on Windows (#191)
 - Add `TDF_SIZE_TO_CONTENT` to `TaskDialogIndirect` config so that it can display longer text without truncating/wrapping (80 characters instead of 55) (#202)
 - Fix `xdg-portal` backend not accepting special characters in message dialogs
+- Make `set_parent` require `HasWindowHandle + HasDisplayHandle`
 
 ## 0.14.0
 - i18n for GTK and XDG Portal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `TDF_SIZE_TO_CONTENT` to `TaskDialogIndirect` config so that it can display longer text without truncating/wrapping (80 characters instead of 55) (#202)
 - Fix `xdg-portal` backend not accepting special characters in message dialogs
 - Make `set_parent` require `HasWindowHandle + HasDisplayHandle`
+- Add support for `set_parent` in XDG Portals
 
 ## 0.14.0
 - i18n for GTK and XDG Portal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,10 +38,14 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "rand",
+ "raw-window-handle",
  "serde",
  "serde_repr",
  "tokio",
  "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -398,6 +402,21 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "endi"
@@ -770,6 +789,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1037,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1161,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde"
@@ -1515,6 +1559,66 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
+dependencies = [
+ "bitflags",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ windows-sys = { version = "0.48", features = [
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 # XDG Desktop Portal
-ashpd = { version = "0.8", optional = true, default-features = false }
+ashpd = { version = "0.8", optional = true, default-features = false, features = ["raw_handle"] }
 urlencoding = { version = "2.1.0", optional = true }
 pollster = { version = "0.3", optional = true }
 # GTK

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -3,8 +3,7 @@ use crate::FileHandle;
 use std::path::Path;
 use std::path::PathBuf;
 
-use raw_window_handle::HasWindowHandle;
-use raw_window_handle::RawWindowHandle;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Filter {
@@ -24,6 +23,7 @@ pub struct FileDialog {
     pub(crate) file_name: Option<String>,
     pub(crate) title: Option<String>,
     pub(crate) parent: Option<RawWindowHandle>,
+    pub(crate) parent_display: Option<RawDisplayHandle>,
     pub(crate) can_create_directories: Option<bool>,
 }
 
@@ -90,8 +90,9 @@ impl FileDialog {
 
     /// Set parent windows explicitly (optional)
     /// Suported in: `macos` and `windows`
-    pub fn set_parent<W: HasWindowHandle>(mut self, parent: &W) -> Self {
+    pub fn set_parent<W: HasWindowHandle + HasDisplayHandle>(mut self, parent: &W) -> Self {
         self.parent = parent.window_handle().ok().map(|x| x.as_raw());
+        self.parent_display = parent.display_handle().ok().map(|x| x.as_raw());
         self
     }
 
@@ -208,7 +209,7 @@ impl AsyncFileDialog {
 
     /// Set parent windows explicitly (optional)
     /// Suported in: `macos` and `windows`
-    pub fn set_parent<W: HasWindowHandle>(mut self, parent: &W) -> Self {
+    pub fn set_parent<W: HasWindowHandle + HasDisplayHandle>(mut self, parent: &W) -> Self {
         self.file_dialog = self.file_dialog.set_parent(parent);
         self
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -88,8 +88,11 @@ impl FileDialog {
         self
     }
 
-    /// Set parent windows explicitly (optional)
-    /// Suported in: `macos` and `windows`
+    /// Set parent windows explicitly (optional).
+    /// Supported platforms:
+    ///  * Windows
+    ///  * Mac
+    ///  * Linux (XDG only)
     pub fn set_parent<W: HasWindowHandle + HasDisplayHandle>(mut self, parent: &W) -> Self {
         self.parent = parent.window_handle().ok().map(|x| x.as_raw());
         self.parent_display = parent.display_handle().ok().map(|x| x.as_raw());
@@ -207,8 +210,11 @@ impl AsyncFileDialog {
         self
     }
 
-    /// Set parent windows explicitly (optional)
-    /// Suported in: `macos` and `windows`
+    /// Set parent windows explicitly (optional).
+    /// Supported platforms:
+    ///  * Windows
+    ///  * Mac
+    ///  * Linux (XDG only)
     pub fn set_parent<W: HasWindowHandle + HasDisplayHandle>(mut self, parent: &W) -> Self {
         self.file_dialog = self.file_dialog.set_parent(parent);
         self

--- a/src/message_dialog.rs
+++ b/src/message_dialog.rs
@@ -4,8 +4,7 @@ use std::fmt::{Display, Formatter};
 
 use std::future::Future;
 
-use raw_window_handle::HasWindowHandle;
-use raw_window_handle::RawWindowHandle;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle};
 
 /// Synchronous Message Dialog. Supported platforms:
 ///  * Windows
@@ -19,6 +18,7 @@ pub struct MessageDialog {
     pub(crate) level: MessageLevel,
     pub(crate) buttons: MessageButtons,
     pub(crate) parent: Option<RawWindowHandle>,
+    pub(crate) parent_display: Option<RawDisplayHandle>,
 }
 
 // Oh god, I don't like sending RawWindowHandle between threads but here we go anyways...
@@ -66,8 +66,9 @@ impl MessageDialog {
 
     /// Set parent windows explicitly (optional)
     /// Suported in: `macos` and `windows`
-    pub fn set_parent<W: HasWindowHandle>(mut self, parent: &W) -> Self {
+    pub fn set_parent<W: HasWindowHandle + HasDisplayHandle>(mut self, parent: &W) -> Self {
         self.parent = parent.window_handle().ok().map(|x| x.as_raw());
+        self.parent_display = parent.display_handle().ok().map(|x| x.as_raw());
         self
     }
 
@@ -126,7 +127,7 @@ impl AsyncMessageDialog {
 
     /// Set parent windows explicitly (optional)
     /// Suported in: `macos` and `windows`
-    pub fn set_parent<W: HasWindowHandle>(mut self, parent: &W) -> Self {
+    pub fn set_parent<W: HasWindowHandle + HasDisplayHandle>(mut self, parent: &W) -> Self {
         self.0 = self.0.set_parent(parent);
         self
     }

--- a/src/message_dialog.rs
+++ b/src/message_dialog.rs
@@ -64,8 +64,11 @@ impl MessageDialog {
         self
     }
 
-    /// Set parent windows explicitly (optional)
-    /// Suported in: `macos` and `windows`
+    /// Set parent windows explicitly (optional).
+    /// Supported platforms:
+    ///  * Windows
+    ///  * Mac
+    ///  * Linux (XDG only)
     pub fn set_parent<W: HasWindowHandle + HasDisplayHandle>(mut self, parent: &W) -> Self {
         self.parent = parent.window_handle().ok().map(|x| x.as_raw());
         self.parent_display = parent.display_handle().ok().map(|x| x.as_raw());
@@ -125,8 +128,11 @@ impl AsyncMessageDialog {
         self
     }
 
-    /// Set parent windows explicitly (optional)
-    /// Suported in: `macos` and `windows`
+    /// Set parent windows explicitly (optional).
+    /// Supported platforms:
+    ///  * Windows
+    ///  * Mac
+    ///  * Linux (XDG only)
     pub fn set_parent<W: HasWindowHandle + HasDisplayHandle>(mut self, parent: &W) -> Self {
         self.0 = self.0.set_parent(parent);
         self


### PR DESCRIPTION
Related to https://github.com/PolyMeilex/rfd/issues/46.

This PR ads support for `set_parent` for XDG Portals. As mentioned in https://github.com/PolyMeilex/rfd/issues/46, that requires making the parent to be `HasWindowHandle + HasDisplayHandle` due to `WindowIdentifier` on Wayland requiring a `RawDisplayHandle`.

Currently the code calls `block_on` when constructing a `WindowIdentifier` due to the fact that the handles are not `Send`, but it's much better compared to not having the feature at all \:)

Tested on X11.