### PR TITLE
Add Clone and Debug traits for `FileHandle`

### DIFF
--- a/src/file_handle/native.rs
+++ b/src/file_handle/native.rs
@@ -110,6 +110,7 @@ impl Future for Writer {
 }
 
 /// FileHandle is a way of abstracting over a file returned by a dialog
+#[derive(Clone, Debug)]
 pub struct FileHandle(PathBuf);
 
 impl FileHandle {

--- a/src/file_handle/web.rs
+++ b/src/file_handle/web.rs
@@ -8,6 +8,7 @@ pub(crate) enum WasmFileHandleKind {
     Writable(FileDialog),
 }
 
+#[derive(Clone, Debug)]
 pub struct FileHandle(pub(crate) WasmFileHandleKind);
 
 impl FileHandle {


### PR DESCRIPTION
This PR adds Clone and Debug trait implementations to the FileHandle type using derive macros. Since FileHandle is just a wrapper for the platform file path, and in both native and web environments the inner type implements these traits, it is useful to add them. especially  for Clone, because it is required in many scenarios.