### PR TITLE
Bugfix: Fail to dismiss the Message Dialog merely in MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -797,16 +796,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,10 +331,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "deferred-future"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5131db302b3cb350203ec927491d6e7dc34da02ac14978c923444a42e34f33b"
+dependencies = [
+ "futures",
+]
 
 [[package]]
 name = "dispatch"
@@ -482,6 +507,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -774,6 +800,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,10 +1043,13 @@ checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "rfd"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ashpd",
  "block2",
+ "core-foundation",
+ "core-foundation-sys",
+ "deferred-future",
  "futures",
  "glib-sys",
  "gobject-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,6 @@ objc2-app-kit = { version = "0.2.0", features = [
   "NSView",
   "NSWindow",
 ] }
-futures = { version = "0.3.12", features = [
-    "thread-pool"
-]}
 deferred-future = "0.1.5"
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,12 @@ objc2-app-kit = { version = "0.2.0", features = [
   "NSView",
   "NSWindow",
 ] }
+futures = { version = "0.3.12", features = [
+    "thread-pool"
+]}
+deferred-future = "0.1.5"
+core-foundation = "0.10.0"
+core-foundation-sys = "0.8.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.48", features = [

--- a/examples/msg.rs
+++ b/examples/msg.rs
@@ -1,7 +1,8 @@
+use ::std::io::{ Read, self };
+use ::futures::executor::block_on;
 fn main() {
     #[cfg(not(feature = "gtk3"))]
     let res = "";
-
     #[cfg(any(
         target_os = "windows",
         target_os = "macos",
@@ -20,7 +21,37 @@ fn main() {
         .set_title("Msg!")
         .set_description("Description!")
         .set_buttons(rfd::MessageButtons::OkCancel)
+        .set_level(rfd::MessageLevel::Error)
         .show();
-
-    println!("{}", res);
+    println!("被点击按钮是 {}。敲击 Ctrl+D 继续。", res);
+    let mut stdin = io::stdin();
+    let mut buffer: Vec<u8> = vec![];
+    stdin.read_to_end(&mut buffer).unwrap();
+    #[cfg(any(
+        target_os = "windows",
+        target_os = "macos",
+        all(
+            any(
+                target_os = "linux",              
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ),
+            feature = "gtk3"
+        )
+    ))]
+    block_on(async move {
+        let res = rfd::AsyncMessageDialog::new()
+            .set_title("Msg!")
+            .set_description("Description!")
+            .set_buttons(rfd::MessageButtons::OkCancel)
+            .show().await;
+        println!("被点击按钮是 {}", res);
+    });
+    println!("敲击 Ctrl+D 继续。");
+    let mut stdin = io::stdin();
+    let mut buffer: Vec<u8> = vec![];
+    stdin.read_to_end(&mut buffer).unwrap();
+    println!("结束");
 }

--- a/src/backend/macos/message_dialog.rs
+++ b/src/backend/macos/message_dialog.rs
@@ -169,12 +169,11 @@ use crate::backend::AsyncMessageDialogImpl;
 
 impl AsyncMessageDialogImpl for MessageDialog {
     fn show_async(self) -> DialogFutureType<MessageDialogResult> {
-        let win = self.parent.as_ref().map(window_from_raw_window_handle);
         if self.parent.is_none() {
             utils::async_pop_dialog(self)
         } else {
             Box::pin(ModalFuture::new(
-                win,
+                self.parent.as_ref().map(window_from_raw_window_handle),
                 move |mtm| Alert::new(self, mtm),
                 |dialog, ret| dialog_result(&dialog.buttons, ret),
             ))

--- a/src/backend/macos/utils.rs
+++ b/src/backend/macos/utils.rs
@@ -1,8 +1,10 @@
 mod focus_manager;
 mod policy_manager;
+mod user_alert;
 
-pub use self::focus_manager::FocusManager;
-pub use self::policy_manager::PolicyManager;
+pub use focus_manager::FocusManager;
+pub use policy_manager::PolicyManager;
+pub use user_alert::{ async_pop_dialog, sync_pop_dialog };
 
 use objc2::rc::Id;
 use objc2_app_kit::{NSApplication, NSView, NSWindow};

--- a/src/backend/macos/utils/user_alert.rs
+++ b/src/backend/macos/utils/user_alert.rs
@@ -25,7 +25,7 @@ struct UserAlert {
     _policy_manager: Option<PolicyManager>,
 }
 impl UserAlert {
-    pub fn new(opt: MessageDialog, mtm: Option<MainThreadMarker>) -> Self {
+    fn new(opt: MessageDialog, mtm: Option<MainThreadMarker>) -> Self {
         let mut buttons: [Option<String>; 3] = match &opt.buttons {
             MessageButtons::Ok => [None, None, None],
             MessageButtons::OkCancel => [None, Some("Cancel".to_string()), None],
@@ -55,7 +55,7 @@ impl UserAlert {
             _focus_manager: mtm.map(|mtm| FocusManager::new(mtm))
         }
     }
-    pub fn run(self) -> MessageDialogResult {
+    fn run(self) -> MessageDialogResult {
         let alert_header =  CFString::new(&self.alert_header[..]);
         let alert_message = CFString::new(&self.alert_message[..]);
         let default_button_title = self.default_button_title.map(|string| CFString::new(&string[..]));

--- a/src/backend/macos/utils/user_alert.rs
+++ b/src/backend/macos/utils/user_alert.rs
@@ -1,0 +1,120 @@
+use ::objc2::rc::autoreleasepool;
+use ::objc2_foundation::MainThreadMarker;
+use ::deferred_future::ThreadDeferredFuture;
+use ::std::{ mem::MaybeUninit, ptr, sync::PoisonError };
+use ::core_foundation::{ base::TCFType, string::CFString };
+use ::futures::{ future, executor::ThreadPool, task::SpawnExt };
+use ::core_foundation_sys::{ base::CFOptionFlags, date::CFTimeInterval, url::CFURLRef, user_notification::{ CFUserNotificationDisplayAlert, kCFUserNotificationStopAlertLevel, kCFUserNotificationCautionAlertLevel, kCFUserNotificationNoteAlertLevel,  kCFUserNotificationDefaultResponse, kCFUserNotificationAlternateResponse, kCFUserNotificationOtherResponse } };
+use crate::{
+    message_dialog::{ MessageButtons, MessageDialog, MessageDialogResult, MessageLevel },
+    backend::{ DialogFutureType, macos::utils::{ FocusManager, PolicyManager, run_on_main } }
+};
+struct UserAlert {
+    timeout: CFTimeInterval,
+    flags: CFOptionFlags,
+    icon_url: CFURLRef,
+    sound_url: CFURLRef,
+    localization_url: CFURLRef,
+    alert_header: String,
+    alert_message: String,
+    default_button_title: Option<String>,
+    alternate_button_title: Option<String>,
+    other_button_title: Option<String>,
+    buttons: MessageButtons,
+    _focus_manager: Option<FocusManager>,
+    _policy_manager: Option<PolicyManager>,
+}
+impl UserAlert {
+    pub fn new(opt: MessageDialog, mtm: Option<MainThreadMarker>) -> Self {
+        let mut buttons: [Option<String>; 3] = match &opt.buttons {
+            MessageButtons::Ok => [None, None, None],
+            MessageButtons::OkCancel => [None, Some("Cancel".to_string()), None],
+            MessageButtons::YesNo => [Some("Yes".to_string()), Some("No".to_string()), None],
+            MessageButtons::YesNoCancel => [Some("Yes".to_string()), Some("No".to_string()), Some("Cancel".to_string())],
+            MessageButtons::OkCustom(ok_text) => [Some(ok_text.to_string()), None, None],
+            MessageButtons::OkCancelCustom(ok_text, cancel_text) => [Some(ok_text.to_string()), Some(cancel_text.to_string()), None],
+            MessageButtons::YesNoCancelCustom(yes_text, no_text, cancel_text) => [Some(yes_text.to_string()), Some(no_text.to_string()), Some(cancel_text.to_string())]
+        };
+        UserAlert {
+            timeout: 0_f64,
+            icon_url: ptr::null(),
+            sound_url: ptr::null(),
+            localization_url: ptr::null(),
+            flags: match opt.level {
+                MessageLevel::Info => kCFUserNotificationNoteAlertLevel,
+                MessageLevel::Warning => kCFUserNotificationCautionAlertLevel,
+                MessageLevel::Error => kCFUserNotificationStopAlertLevel
+            },
+            alert_header: opt.title,
+            alert_message: opt.description,
+            default_button_title: buttons[0].take(),
+            alternate_button_title: buttons[1].take(),
+            other_button_title: buttons[2].take(),
+            buttons: opt.buttons,
+            _policy_manager: mtm.map(|mtm| PolicyManager::new(mtm)),
+            _focus_manager: mtm.map(|mtm| FocusManager::new(mtm))
+        }
+    }
+    pub fn run(self) -> MessageDialogResult {
+        let alert_header =  CFString::new(&self.alert_header[..]);
+        let alert_message = CFString::new(&self.alert_message[..]);
+        let default_button_title = self.default_button_title.map(|string| CFString::new(&string[..]));
+        let alternate_button_title = self.alternate_button_title.map(|value| CFString::new(&value[..]));
+        let other_button_title = self.other_button_title.map(|value| CFString::new(&value[..]));
+        let mut response_flags = MaybeUninit::<CFOptionFlags>::uninit();
+        let is_canel = unsafe { CFUserNotificationDisplayAlert(
+            self.timeout,
+            self.flags,
+            self.icon_url,
+            self.sound_url,
+            self.localization_url,
+            alert_header.as_concrete_TypeRef(),
+            alert_message.as_concrete_TypeRef(),
+            default_button_title.map_or(ptr::null(), |value| value.as_concrete_TypeRef()),
+            alternate_button_title.map_or(ptr::null(), |value| value.as_concrete_TypeRef()),
+            other_button_title.map_or(ptr::null(), |value| value.as_concrete_TypeRef()),
+            response_flags.as_mut_ptr()
+        ) };
+        if is_canel != 0 {
+            return MessageDialogResult::Cancel;
+        }
+        let response = unsafe { response_flags.assume_init() };
+        match self.buttons {
+            MessageButtons::Ok if response == kCFUserNotificationDefaultResponse => MessageDialogResult::Ok,
+            MessageButtons::OkCancel if response == kCFUserNotificationDefaultResponse => MessageDialogResult::Ok,
+            MessageButtons::OkCancel if response == kCFUserNotificationAlternateResponse => MessageDialogResult::Cancel,
+            MessageButtons::YesNo if response == kCFUserNotificationDefaultResponse => MessageDialogResult::Yes,
+            MessageButtons::YesNo if response == kCFUserNotificationAlternateResponse => MessageDialogResult::No,
+            MessageButtons::YesNoCancel if response == kCFUserNotificationDefaultResponse => MessageDialogResult::Yes,
+            MessageButtons::YesNoCancel if response == kCFUserNotificationAlternateResponse => MessageDialogResult::No,
+            MessageButtons::YesNoCancel if response == kCFUserNotificationOtherResponse => MessageDialogResult::Cancel,
+            MessageButtons::OkCustom(custom) if response == kCFUserNotificationDefaultResponse => MessageDialogResult::Custom(custom.to_owned()),
+            MessageButtons::OkCancelCustom(custom, _) if response == kCFUserNotificationDefaultResponse => MessageDialogResult::Custom(custom.to_owned()),
+            MessageButtons::OkCancelCustom(_, custom) if response == kCFUserNotificationAlternateResponse => MessageDialogResult::Custom(custom.to_owned()),
+            MessageButtons::YesNoCancelCustom(custom, _, _) if response == kCFUserNotificationDefaultResponse => MessageDialogResult::Custom(custom.to_owned()),
+            MessageButtons::YesNoCancelCustom(_, custom, _) if response == kCFUserNotificationAlternateResponse => MessageDialogResult::Custom(custom.to_owned()),
+            MessageButtons::YesNoCancelCustom(_, _, custom) if response == kCFUserNotificationOtherResponse => MessageDialogResult::Custom(custom.to_owned()),
+            _ => MessageDialogResult::Cancel,
+        }
+    }
+}
+pub fn sync_pop_dialog(opt: MessageDialog, mtm: MainThreadMarker) -> MessageDialogResult {
+    UserAlert::new(opt, Some(mtm)).run()
+}
+pub fn async_pop_dialog(opt: MessageDialog) -> DialogFutureType<MessageDialogResult> {
+    let deferred_future = ThreadDeferredFuture::default();
+    let defer = deferred_future.defer();
+    let opt2 = opt.clone();
+    let result: Result<(), String> = ThreadPool::new().map_err(|err| err.to_string()).and_then(|thread_pool| thread_pool.spawn(async move {
+        let mut defer = defer.lock().unwrap_or_else(PoisonError::into_inner);
+        let message_dialog_result = UserAlert::new(opt2.clone(), None).run();
+        defer.complete(message_dialog_result);
+    }).map_err(|err| err.to_string()));
+    match result {
+        Ok(_) => Box::pin(deferred_future),
+        Err(err) => {
+            eprintln!("\n Hi! It looks like you are running async dialog in unsupported environment, I will fallback to sync dialog for you. Reason is as below:\n {}", err);
+            Box::pin(future::ready(autoreleasepool(move |_| run_on_main(move |mtm| UserAlert::new(opt, Some(mtm)).run()))))
+        }
+    }
+}


### PR DESCRIPTION
1. Bug phenomenon: Only in MacOS, the message dialog originating from the command-line context fails to dismiss itself posterior to clicking the button "OK".
2. Solution: If the parent-window handle is absent during the initialization of the MessageDialog instance, the alternative ABI `CFUserNotificationDisplayAlert` will be invoked to pop up a message dialog, instead of instantiating a NSAlert object.
3. Ramification: Only message dialog for MacOS
4. Unit Test: It covers both sync and async message dialogs and is run by `cargo run --example msg`