### PR TITLE
Fix crash due to not handling dialog window close event

### DIFF
--- a/src/backend/gtk3/message_dialog.rs
+++ b/src/backend/gtk3/message_dialog.rs
@@ -209,6 +209,7 @@ impl AsyncMessageDialogImpl for MessageDialog {
             gtk_sys::GTK_RESPONSE_CANCEL => MessageDialogResult::Cancel,
             gtk_sys::GTK_RESPONSE_YES => MessageDialogResult::Yes,
             gtk_sys::GTK_RESPONSE_NO => MessageDialogResult::No,
+            gtk_sys::GTK_RESPONSE_DELETE_EVENT => MessageDialogResult::Cancel,
             _ => unreachable!(),
         });
         Box::pin(future)


### PR DESCRIPTION
Fixes crash from #219

Quick link to line defining GTK_RESPONSE_DELETE_EVENT, which is the response when the dialog window is closed:
https://gitlab.gnome.org/GNOME/gtk/-/blob/gtk-3-24/gtk/gtkdialog.h#L60