### PR TITLE
fix: the `pick_file()` can return `None` when cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 # Change Log
 
 ## Unreleased
+
 - Fix regressions on Wayland due to `ashpd` upgrade (#255).
+- The `pick_file()` method of file dialog targeted WASM now can return `None` correctly when cancelled (#258)
 
 ## 0.15.3
+
 - Update `objc2` to v0.6.
 - Update `ashpd` to 0.11.
 
 ## 0.15.1
+
 - Update `ashpd` to 0.10.
 - Fix issue where with no filter added no files are selectable on Windows (#211).
 
 ## 0.15.0
+
 - Move from `objc` crates to `objc2` crates.
 - Fix `AsyncFileDialog` blocking the executor on Windows (#191)
 - Add `TDF_SIZE_TO_CONTENT` to `TaskDialogIndirect` config so that it can display longer text without truncating/wrapping (80 characters instead of 55) (#202)
@@ -23,6 +28,7 @@
 - Derive `Clone` for `FileHandle`
 
 ## 0.14.0
+
 - i18n for GTK and XDG Portal
 - Use XDG Portal as default
 - Use zenity as a fallback for XDG Portal
@@ -34,14 +40,17 @@
 - Add `FileDialog/AsyncFileDialog::set_can_create_directories`, supported on macOS only.
 
 ## 0.13.0
+
 - **[Breaking]** Users of the `xdg-portal` feature must now also select the `tokio`
   or `async-std` feature
 - [macOS] Use NSOpenPanel.message instead of title #166
 
 ## 0.12.1
+
 - Fix `FileHandle::inner` (under feature `file-handle-inner`) on wasm
 
 ## 0.12.0
+
 - Add title support for WASM (#132)
 - Add Create folder button to `pick_folder` on macOS (#127)
 - Add support for Yes/No/Cancel buttons (#123)
@@ -53,38 +62,48 @@
 - Make zenity related deps optional (#141)
 
 ## 0.11.3
+
 - Zenity message dialogs for xdg portal backend
 
 ## 0.10.1
+
 - Update `gtk-sys` to `0.16` and `windows-rs` to `0.44`
 
 ## 0.10.0
+
 - fix(FileDialog::set_directory): fallback to default if path is empty
 
 ## 0.9.0
+
 - feat: customize button text, Close #74
 - feat: Add support for selecting multiple folders, fixes #73
 
 ## 0.8.4
+
 - XDG: decode URI before converting to PathBuf #70
 
 ## 0.8.3
+
 - Windows-rs update 0.37
 
 ## 0.8.2
+
 - Windows-rs update 0.35
 
 ## 0.8.1
+
 - Macos parent for sync FileDialog (#58)
 - Windows-rs update 0.33
 
 ## 0.8.0
+
 - `parent` feature was removed, it is always on now
 - New feature `xdg-portal`
 - Now you have to choose one of the features `gtk3` or `xdg-portal`, gtk is on by default
 - `window` crate got updated to 0.32
 
 ## 0.7.0
+
 - Safe Rust XDG Desktop Portal support
 
 ## 0.6.3
@@ -92,9 +111,11 @@
 - Update `windows` crate to 0.30.
 
 ## 0.6.2
+
 - Strip Win32 namespaces from directory paths
 
 ## 0.6.0
+
 - FreeBSD support
 - Port to windows-rs
 - Update RawWindowHandle to 0.4

--- a/examples/winit-example/Cargo.lock
+++ b/examples/winit-example/Cargo.lock
@@ -92,6 +92,9 @@ dependencies = [
  "serde",
  "serde_repr",
  "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.8",
  "zbus",
 ]
 
@@ -1365,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "ashpd",
  "block2 0.6.1",
@@ -1525,7 +1528,7 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
@@ -1906,6 +1909,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols"
+version = "0.32.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-protocols-plasma"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,7 +1929,7 @@ dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-scanner",
 ]
 
@@ -1927,7 +1942,7 @@ dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-scanner",
 ]
 
@@ -2312,7 +2327,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",

--- a/examples/winit-example/Trunk.toml
+++ b/examples/winit-example/Trunk.toml
@@ -1,2 +1,2 @@
 [watch]
-watch = ["../../src"]
+watch = ["../../src", "src"]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,7 @@
 use crate::message_dialog::MessageDialogResult;
 use crate::FileHandle;
 use std::future::Future;
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 use std::pin::Pin;
 
@@ -90,6 +91,7 @@ pub trait AsyncFilePickerDialogImpl {
 }
 
 /// Dialog used to pick folder
+#[cfg(not(target_arch = "wasm32"))]
 pub trait AsyncFolderPickerDialogImpl {
     fn pick_folder_async(self) -> DialogFutureType<Option<FileHandle>>;
     fn pick_folders_async(self) -> DialogFutureType<Option<Vec<FileHandle>>>;


### PR DESCRIPTION
Hey dude,

I feel apologetic for such a slipup.

In my earlier PR #252, the overlay was removed directly from the `body`, which left the _JavaScript Promise_ unresolved, breaking the event loop during `.await` and preventing the correct return value `None` from being obtained from `pick_file()`. 

To address this issue, the _Promise_ will now be rejected if cancelled. Since the current `show()` does not permit failure, I am marking the future result with `.ok()` instead of `.unwrap()`. Hope it's good enough this time 😅 