### PR TITLE
make wayland optional and enable it by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix regressions on Wayland due to `ashpd` upgrade (#255).
 - The `pick_file()` method of file dialog targeted WASM now can return `None` correctly when cancelled (#258)
 - Update `windows-sys` to 0.60.
+- Make `ashpd` Wayland APIs optional. These are now gated behind the `wayland` feature, which is enabled by default.
 
 ## 0.15.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/PolyMeilex/rfd"
 documentation = "https://docs.rs/rfd"
 
 [features]
-default = ["xdg-portal", "async-std"]
+default = ["xdg-portal", "wayland", "async-std"]
 file-handle-inner = []
 gtk3 = ["gtk-sys", "glib-sys", "gobject-sys"]
 xdg-portal = ["ashpd", "urlencoding", "pollster"]
@@ -19,6 +19,8 @@ xdg-portal = ["ashpd", "urlencoding", "pollster"]
 async-std = ["ashpd?/async-std"]
 # Use tokio for xdg-portal
 tokio = ["ashpd?/tokio"]
+# Enable wayland support for xdg-portal
+wayland = ["ashpd?/wayland"]
 common-controls-v6 = ["windows-sys/Win32_UI_Controls"]
 
 [dev-dependencies]
@@ -77,7 +79,6 @@ windows-sys = { version = "0.60", features = [
 # XDG Desktop Portal
 ashpd = { version = "0.11", optional = true, default-features = false, features = [
   "raw_handle",
-  "wayland",
 ] }
 urlencoding = { version = "2.1.0", optional = true }
 pollster = { version = "0.4", optional = true }


### PR DESCRIPTION
fixes #226 

In my project, which currently can't support wayland, this saves 18 dependencies, about 250KiB of binary size and about 3 seconds (~20%) of `cargo check` time. These measurements include the workaround mentioned in https://github.com/PolyMeilex/rfd/pull/255#issuecomment-3076271798, without applying it beforehand this change saves even more.

This is a breaking change since it changes the default features.