### PR TITLE
chore: fix typo in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `FileDialog::set_show_hidden_files` and `AsyncFileDialog::set_show_hidden_files` to control hidden file visibility. Supported on macOS, Windows, and Linux (GTK3).
 - Honor `FileDialog::set_directory` and `AsyncFileDialog::set_directory` when using the zenity fallback backend on Linux.
+- Fix `liblary` typo in docs
 
 ## 0.17.2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,8 @@
 //! The XDG Desktop Portal backend is used with the `xdg-portal` Cargo feature which is enabled by default. This backend will use either the GTK or KDE file dialog depending on the desktop environment
 //! in use at runtime.
 //!
-//! It requires the user to have `libdbus` system liblary (should be available on any systemd
-//! distro), if the liblary is not found `zenity` will be used instead.
+//! It requires the user to have `libdbus` system library (should be available on any systemd
+//! distro), if the library is not found `zenity` will be used instead.
 //!
 //! It requires the user to also have either the
 //! [GTK](https://github.com/flatpak/xdg-desktop-portal-gtk),


### PR DESCRIPTION
- Fixes `liblary` typo in docs