### PR TITLE
Fix GTK message dialog title duplication

### DIFF
--- a/src/backend/gtk3/message_dialog.rs
+++ b/src/backend/gtk3/message_dialog.rs
@@ -92,9 +92,6 @@ impl GtkMessageDialog {
             ) as *mut gtk_sys::GtkDialog;
 
             set_child_labels_selectable(dialog);
-            // Also set the window title, otherwise it would be empty
-            gtk_sys::gtk_window_set_title(dialog as _, title.as_ptr());
-
             for custom_button in custom_buttons {
                 if let Some((custom_button_cstr, response_id)) = custom_button {
                     gtk_sys::gtk_dialog_add_button(


### PR DESCRIPTION
## Summary

This PR reverts #94 (`1646d5ac84f4b31`) to fix the GTK3 message dialog title duplication.

Before this change, the GTK3 backend passed `opt.title` to both:
- `gtk_message_dialog_new(..., "%s", title)`, which renders it as the primary bold text inside the dialog body.
- `gtk_window_set_title(..., title)` (introduced in #94), which renders it as the native window manager titlebar text.

This caused the title to be duplicated on desktop environments that render window titlebars (e.g. SSD, tiling window managers, or GNOME when parent is not bound), showing the title twice.

Reverting the title setting ensures that the title is only shown once as the primary bold text in the dialog body, which is the standard design for GTK dialogs and aligns with GNOME Human Interface Guidelines.

## References

- **GNOME HIG 2.2.2 (Section 3.4 Alerts)**:
  > "Alert windows have no titles, as the title would usually unnecessarily duplicate the alert's primary text."
  >
  > [Archived HIG Reference Link](https://web.archive.org/web/2015/https://developer.gnome.org/hig-book/3.0/windows-alert.html.en)

## Reproduction

This can be reproduced through Tauri's dialog plugin.

The JS API call:

```javascript
await message(
  "This window has unsaved changes. Open the workspace in a new window instead?",
  {
    title: "Unsaved Changes",
    kind: "warning"
  }
);
```

Before this change, the dialog shows "Unsaved Changes" twice: once in the window titlebar and once as the primary bold text inside the dialog.
After this change, the duplicate title in the window titlebar is removed, showing "Unsaved Changes" only once in the dialog body as the primary bold text, and the description below it.

## Verification

Verified with a minimal Tauri app using `@tauri-apps/plugin-dialog` and RFD's GTK3 backend:
- The title "Unsaved Changes" is shown correctly as primary bold text inside the dialog body.
- The window manager titlebar no longer displays the duplicate title.
