### PR TITLE
feat(gtk3): bind dialog transient parent using RawWindowHandle

### DIFF
--- a/src/backend/gtk3/file_dialog/dialog_ffi.rs
+++ b/src/backend/gtk3/file_dialog/dialog_ffi.rs
@@ -160,19 +160,22 @@ impl GtkFileDialog {
     }
 }
 
+fn parent_gtk_window(opt: &FileDialog) -> *mut gtk_sys::GtkWindow {
+    let mut parent_gtk_window = std::ptr::null_mut();
+    if let Some(parent_handle) = &opt.parent {
+        unsafe {
+            parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
+        }
+    }
+    parent_gtk_window
+}
+
 impl GtkFileDialog {
     pub fn build_pick_file(opt: &FileDialog) -> Self {
-        let mut parent_gtk_window = std::ptr::null_mut();
-        if let Some(parent_handle) = &opt.parent {
-            unsafe {
-                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
-            }
-        }
-
         let mut dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Open File"),
             GtkFileChooserAction::Open,
-            parent_gtk_window,
+            parent_gtk_window(opt),
         );
 
         dialog.add_filters(&opt.filters);
@@ -192,17 +195,10 @@ impl GtkFileDialog {
     }
 
     pub fn build_save_file(opt: &FileDialog) -> Self {
-        let mut parent_gtk_window = std::ptr::null_mut();
-        if let Some(parent_handle) = &opt.parent {
-            unsafe {
-                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
-            }
-        }
-
         let mut dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Save File"),
             GtkFileChooserAction::Save,
-            parent_gtk_window,
+            parent_gtk_window(opt),
         );
 
         unsafe { gtk_sys::gtk_file_chooser_set_do_overwrite_confirmation(dialog.ptr as _, 1) };
@@ -231,17 +227,10 @@ impl GtkFileDialog {
     }
 
     pub fn build_pick_folder(opt: &FileDialog) -> Self {
-        let mut parent_gtk_window = std::ptr::null_mut();
-        if let Some(parent_handle) = &opt.parent {
-            unsafe {
-                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
-            }
-        }
-
         let dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Select Folder"),
             GtkFileChooserAction::SelectFolder,
-            parent_gtk_window,
+            parent_gtk_window(opt),
         );
         dialog.set_path(opt.starting_directory.as_deref());
         dialog.set_show_hidden(opt.show_hidden_files);
@@ -259,17 +248,10 @@ impl GtkFileDialog {
     }
 
     pub fn build_pick_folders(opt: &FileDialog) -> Self {
-        let mut parent_gtk_window = std::ptr::null_mut();
-        if let Some(parent_handle) = &opt.parent {
-            unsafe {
-                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
-            }
-        }
-
         let dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Select Folder"),
             GtkFileChooserAction::SelectFolder,
-            parent_gtk_window,
+            parent_gtk_window(opt),
         );
         unsafe { gtk_sys::gtk_file_chooser_set_select_multiple(dialog.ptr as _, 1) };
         dialog.set_path(opt.starting_directory.as_deref());
@@ -288,17 +270,10 @@ impl GtkFileDialog {
     }
 
     pub fn build_pick_files(opt: &FileDialog) -> Self {
-        let mut parent_gtk_window = std::ptr::null_mut();
-        if let Some(parent_handle) = &opt.parent {
-            unsafe {
-                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
-            }
-        }
-
         let mut dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Open File"),
             GtkFileChooserAction::Open,
-            parent_gtk_window,
+            parent_gtk_window(opt),
         );
 
         unsafe { gtk_sys::gtk_file_chooser_set_select_multiple(dialog.ptr as _, 1) };

--- a/src/backend/gtk3/file_dialog/dialog_ffi.rs
+++ b/src/backend/gtk3/file_dialog/dialog_ffi.rs
@@ -6,7 +6,6 @@ use std::{
     ffi::{CStr, CString},
     ops::Deref,
     path::{Path, PathBuf},
-    ptr,
 };
 
 #[repr(i32)]
@@ -22,13 +21,13 @@ pub struct GtkFileDialog {
 }
 
 impl GtkFileDialog {
-    fn new(title: &str, action: GtkFileChooserAction) -> Self {
+    fn new(title: &str, action: GtkFileChooserAction, parent: *mut gtk_sys::GtkWindow) -> Self {
         let title = CString::new(title).unwrap();
 
         let ptr = unsafe {
             let dialog = gtk_sys::gtk_file_chooser_native_new(
                 title.as_ptr(),
-                ptr::null_mut(),
+                parent,
                 action as i32,
                 // passing null for the texts will use the default text, which has full support for i18n
                 std::ptr::null(),
@@ -163,9 +162,17 @@ impl GtkFileDialog {
 
 impl GtkFileDialog {
     pub fn build_pick_file(opt: &FileDialog) -> Self {
+        let mut parent_gtk_window = std::ptr::null_mut();
+        if let Some(parent_handle) = &opt.parent {
+            unsafe {
+                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
+            }
+        }
+
         let mut dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Open File"),
             GtkFileChooserAction::Open,
+            parent_gtk_window,
         );
 
         dialog.add_filters(&opt.filters);
@@ -185,9 +192,17 @@ impl GtkFileDialog {
     }
 
     pub fn build_save_file(opt: &FileDialog) -> Self {
+        let mut parent_gtk_window = std::ptr::null_mut();
+        if let Some(parent_handle) = &opt.parent {
+            unsafe {
+                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
+            }
+        }
+
         let mut dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Save File"),
             GtkFileChooserAction::Save,
+            parent_gtk_window,
         );
 
         unsafe { gtk_sys::gtk_file_chooser_set_do_overwrite_confirmation(dialog.ptr as _, 1) };
@@ -216,9 +231,17 @@ impl GtkFileDialog {
     }
 
     pub fn build_pick_folder(opt: &FileDialog) -> Self {
+        let mut parent_gtk_window = std::ptr::null_mut();
+        if let Some(parent_handle) = &opt.parent {
+            unsafe {
+                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
+            }
+        }
+
         let dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Select Folder"),
             GtkFileChooserAction::SelectFolder,
+            parent_gtk_window,
         );
         dialog.set_path(opt.starting_directory.as_deref());
         dialog.set_show_hidden(opt.show_hidden_files);
@@ -236,9 +259,17 @@ impl GtkFileDialog {
     }
 
     pub fn build_pick_folders(opt: &FileDialog) -> Self {
+        let mut parent_gtk_window = std::ptr::null_mut();
+        if let Some(parent_handle) = &opt.parent {
+            unsafe {
+                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
+            }
+        }
+
         let dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Select Folder"),
             GtkFileChooserAction::SelectFolder,
+            parent_gtk_window,
         );
         unsafe { gtk_sys::gtk_file_chooser_set_select_multiple(dialog.ptr as _, 1) };
         dialog.set_path(opt.starting_directory.as_deref());
@@ -257,9 +288,17 @@ impl GtkFileDialog {
     }
 
     pub fn build_pick_files(opt: &FileDialog) -> Self {
+        let mut parent_gtk_window = std::ptr::null_mut();
+        if let Some(parent_handle) = &opt.parent {
+            unsafe {
+                parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
+            }
+        }
+
         let mut dialog = GtkFileDialog::new(
             opt.title.as_deref().unwrap_or("Open File"),
             GtkFileChooserAction::Open,
+            parent_gtk_window,
         );
 
         unsafe { gtk_sys::gtk_file_chooser_set_select_multiple(dialog.ptr as _, 1) };

--- a/src/backend/gtk3/file_dialog/dialog_ffi.rs
+++ b/src/backend/gtk3/file_dialog/dialog_ffi.rs
@@ -161,13 +161,11 @@ impl GtkFileDialog {
 }
 
 fn parent_gtk_window(opt: &FileDialog) -> *mut gtk_sys::GtkWindow {
-    let mut parent_gtk_window = std::ptr::null_mut();
     if let Some(parent_handle) = &opt.parent {
-        unsafe {
-            parent_gtk_window = super::super::utils::find_gtk_window(parent_handle);
-        }
+        unsafe { super::super::utils::find_gtk_window(parent_handle) }
+    } else {
+        std::ptr::null_mut()
     }
-    parent_gtk_window
 }
 
 impl GtkFileDialog {

--- a/src/backend/gtk3/message_dialog.rs
+++ b/src/backend/gtk3/message_dialog.rs
@@ -82,8 +82,13 @@ impl GtkMessageDialog {
         let description = CString::new(s).unwrap();
 
         let ptr = unsafe {
+            let mut parent_gtk_window = ptr::null_mut();
+            if let Some(parent_handle) = &opt.parent {
+                parent_gtk_window = super::utils::find_gtk_window(parent_handle);
+            }
+
             let dialog = gtk_sys::gtk_message_dialog_new(
-                ptr::null_mut(),
+                parent_gtk_window,
                 gtk_sys::GTK_DIALOG_MODAL,
                 level,
                 buttons,

--- a/src/backend/gtk3/utils.rs
+++ b/src/backend/gtk3/utils.rs
@@ -131,7 +131,8 @@ pub(super) unsafe fn find_gtk_window(
     let mut current = toplevels;
     let mut found_window = std::ptr::null_mut();
 
-    type GdkX11WindowGetXidFn = unsafe extern "C" fn(*mut std::ffi::c_void) -> std::os::raw::c_ulong;
+    type GdkX11WindowGetXidFn =
+        unsafe extern "C" fn(*mut std::ffi::c_void) -> std::os::raw::c_ulong;
     type GdkWaylandWindowGetWlSurfaceFn =
         unsafe extern "C" fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void;
 

--- a/src/backend/gtk3/utils.rs
+++ b/src/backend/gtk3/utils.rs
@@ -123,3 +123,66 @@ unsafe fn connect_idle<F: FnMut() -> glib_sys::gboolean + Send + 'static>(f: F) 
         Some(destroy_closure::<F>),
     );
 }
+
+pub(super) unsafe fn find_gtk_window(
+    parent: &raw_window_handle::RawWindowHandle,
+) -> *mut gtk_sys::GtkWindow {
+    let toplevels = gtk_sys::gtk_window_list_toplevels();
+    let mut current = toplevels;
+    let mut found_window = std::ptr::null_mut();
+
+    type GdkX11WindowGetXidFn = unsafe extern "C" fn(*mut std::ffi::c_void) -> std::os::raw::c_ulong;
+    type GdkWaylandWindowGetWlSurfaceFn =
+        unsafe extern "C" fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void;
+
+    let gdk_x11_window_get_xid: Option<GdkX11WindowGetXidFn> = std::mem::transmute(libc::dlsym(
+        libc::RTLD_DEFAULT,
+        b"gdk_x11_window_get_xid\0".as_ptr() as *const _,
+    ));
+    let gdk_wayland_window_get_wl_surface: Option<GdkWaylandWindowGetWlSurfaceFn> =
+        std::mem::transmute(libc::dlsym(
+            libc::RTLD_DEFAULT,
+            b"gdk_wayland_window_get_wl_surface\0".as_ptr() as *const _,
+        ));
+
+    while !current.is_null() {
+        let window = (*current).data as *mut gtk_sys::GtkWindow;
+        if gtk_sys::gtk_widget_get_realized(window as _) != 0 {
+            let gdk_window = gtk_sys::gtk_widget_get_window(window as _) as *mut std::ffi::c_void;
+            if !gdk_window.is_null() {
+                match parent {
+                    raw_window_handle::RawWindowHandle::Xlib(h) => {
+                        if let Some(get_xid) = gdk_x11_window_get_xid {
+                            if get_xid(gdk_window) == h.window {
+                                found_window = window;
+                                break;
+                            }
+                        }
+                    }
+                    raw_window_handle::RawWindowHandle::Xcb(h) => {
+                        if let Some(get_xid) = gdk_x11_window_get_xid {
+                            if get_xid(gdk_window) == h.window.get() as std::os::raw::c_ulong {
+                                found_window = window;
+                                break;
+                            }
+                        }
+                    }
+                    raw_window_handle::RawWindowHandle::Wayland(h) => {
+                        if let Some(get_surface) = gdk_wayland_window_get_wl_surface {
+                            if get_surface(gdk_window) == h.surface.as_ptr() {
+                                found_window = window;
+                                break;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        current = (*current).next;
+    }
+
+    glib_sys::g_list_free(toplevels);
+
+    found_window
+}


### PR DESCRIPTION
## Summary

Implement parent window binding in the GTK3 backend using `RawWindowHandle` (supporting X11 and Wayland).

Currently, `rfd` has a cross-platform API for setting a parent window via `.set_parent()`. However, while this was supported on Windows, macOS, and the XDG portal backend, the native GTK3 backend completely ignored the parent window parameter and hardcoded `ptr::null_mut()`.

This PR dynamically resolves the `GtkWindow` pointer corresponding to the provided `RawWindowHandle` by searching the list of top-levels using `gdk_x11_window_get_xid` (X11) and `gdk_wayland_window_get_wl_surface` (Wayland) resolved at runtime via `dlsym`.

This ensures that:
- Dialogs are properly transient/modal to their parent window.
- Under CSD (Client-Side Decoration) desktops like GNOME Shell, modal dialogs are presented as modal sheets attached to the parent window.
