### PR TITLE
macos: Add save-dialog format picker for named filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-foundation",
+ "objc2-uniform-type-identifiers",
 ]
 
 [[package]]
@@ -403,6 +404,16 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d964a85778b5899a7963c5d4a5c62cec6792cf41dfdfc5dadae2d427f2681c85"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -503,6 +514,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+ "objc2-uniform-type-identifiers",
  "percent-encoding",
  "pollster",
  "raw-window-handle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,14 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = [
   "std",
   "NSArray",
   "NSEnumerator",
+  "NSGeometry",
   "NSString",
   "NSThread",
   "NSURL",
+] }
+objc2-uniform-type-identifiers = { version = "0.3.0", default-features = false, features = [
+  "std",
+  "UTType",
 ] }
 objc2-app-kit = { version = "0.3.0", default-features = false, features = [
   "std",
@@ -47,10 +52,13 @@ objc2-app-kit = { version = "0.3.0", default-features = false, features = [
   "NSControl",
   "NSOpenPanel",
   "NSPanel",
+  "NSPopUpButton",
   "NSResponder",
   "NSRunningApplication",
   "NSSavePanel",
+  "NSTextField",
   "NSView",
+  "objc2-uniform-type-identifiers",
   "NSWindow",
 ] }
 objc2-core-foundation = { version = "0.3.0", default-features = false, features = [

--- a/src/backend/macos/file_dialog/panel_ffi.rs
+++ b/src/backend/macos/file_dialog/panel_ffi.rs
@@ -133,15 +133,19 @@ trait PanelExt {
     }
 
     fn add_filters(&self, opt: &FileDialog) {
-        let types: Vec<_> = opt
-            .filters
-            .iter()
-            .flat_map(|filter| filter.extensions.iter())
-            .filter_map(|ext| utype_for_extension(ext))
-            .collect();
+        let mut exts: Vec<String> = Vec::new();
 
-        let array = NSArray::from_retained_slice(&types);
-        unsafe { self.panel().setAllowedContentTypes(&array) };
+        for filter in opt.filters.iter() {
+            exts.append(&mut filter.extensions.to_vec());
+        }
+
+        let f_raw: Vec<_> = exts.iter().map(|ext| NSString::from_str(ext)).collect();
+        let array = NSArray::from_retained_slice(&f_raw);
+
+        unsafe {
+            #[allow(deprecated)]
+            self.panel().setAllowedFileTypes(Some(&array));
+        }
     }
 
     fn set_path(&self, path: &Path, file_name: Option<&str>) {

--- a/src/backend/macos/file_dialog/panel_ffi.rs
+++ b/src/backend/macos/file_dialog/panel_ffi.rs
@@ -4,9 +4,14 @@ use std::path::PathBuf;
 
 use block2::Block;
 use objc2::rc::Retained;
-use objc2::MainThreadMarker;
-use objc2_app_kit::{NSModalResponse, NSOpenPanel, NSSavePanel, NSWindow, NSWindowLevel};
-use objc2_foundation::{NSArray, NSString, NSURL};
+use objc2::runtime::{NSObject, NSObjectProtocol};
+use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadMarker, MainThreadOnly};
+use objc2_app_kit::{
+    NSAutoresizingMaskOptions, NSModalResponse, NSOpenPanel, NSPopUpButton, NSSavePanel,
+    NSTextField, NSView, NSWindow, NSWindowLevel,
+};
+use objc2_foundation::{NSArray, NSPoint, NSRect, NSSize, NSString, NSURL};
+use objc2_uniform_type_identifiers::UTType;
 use raw_window_handle::RawWindowHandle;
 
 use super::super::{
@@ -14,6 +19,7 @@ use super::super::{
     utils::{FocusManager, PolicyManager},
 };
 use crate::backend::macos::utils::window_from_raw_window_handle;
+use crate::file_dialog::Filter;
 use crate::FileDialog;
 
 extern "C" {
@@ -26,6 +32,9 @@ pub struct Panel {
     parent: Option<Retained<NSWindow>>,
     _focus_manager: FocusManager,
     _policy_manager: PolicyManager,
+    // NSControl.target is an unretained (assign) reference, so this is the
+    // only thing keeping the save panel's format-picker handler alive.
+    _save_panel_handler: Option<Retained<SavePanelHandler>>,
 }
 
 impl AsModal for Panel {
@@ -60,6 +69,7 @@ impl Panel {
             parent: parent.map(window_from_raw_window_handle),
             _focus_manager,
             _policy_manager,
+            _save_panel_handler: None,
         }
     }
 
@@ -97,6 +107,20 @@ impl Panel {
     }
 }
 
+fn utype_for_extension(ext: &str) -> Option<Retained<UTType>> {
+    unsafe { UTType::typeWithFilenameExtension(&NSString::from_str(ext)) }
+}
+
+fn utypes_for_filter(filter: &Filter) -> Retained<NSArray<UTType>> {
+    let types: Vec<_> = filter
+        .extensions
+        .iter()
+        .filter_map(|ext| utype_for_extension(ext))
+        .collect();
+
+    NSArray::from_retained_slice(&types)
+}
+
 trait PanelExt {
     fn panel(&self) -> &NSSavePanel;
 
@@ -109,19 +133,15 @@ trait PanelExt {
     }
 
     fn add_filters(&self, opt: &FileDialog) {
-        let mut exts: Vec<String> = Vec::new();
+        let types: Vec<_> = opt
+            .filters
+            .iter()
+            .flat_map(|filter| filter.extensions.iter())
+            .filter_map(|ext| utype_for_extension(ext))
+            .collect();
 
-        for filter in opt.filters.iter() {
-            exts.append(&mut filter.extensions.to_vec());
-        }
-
-        let f_raw: Vec<_> = exts.iter().map(|ext| NSString::from_str(ext)).collect();
-        let array = NSArray::from_retained_slice(&f_raw);
-
-        unsafe {
-            #[allow(deprecated)]
-            self.panel().setAllowedFileTypes(Some(&array));
-        }
+        let array = NSArray::from_retained_slice(&types);
+        unsafe { self.panel().setAllowedContentTypes(&array) };
     }
 
     fn set_path(&self, path: &Path, file_name: Option<&str>) {
@@ -167,6 +187,112 @@ impl PanelExt for Retained<NSOpenPanel> {
     }
 }
 
+struct FormatOption {
+    types: Retained<NSArray<UTType>>,
+}
+
+struct SavePanelHandlerIvars {
+    panel: Retained<NSSavePanel>,
+    options: Vec<FormatOption>,
+}
+
+define_class!(
+    #[unsafe(super = NSObject)]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = SavePanelHandlerIvars]
+    struct SavePanelHandler;
+
+    unsafe impl NSObjectProtocol for SavePanelHandler {}
+
+    impl SavePanelHandler {
+        #[unsafe(method(formatChanged:))]
+        fn format_changed(&self, sender: &NSPopUpButton) {
+            let idx = unsafe { sender.indexOfSelectedItem() };
+            if idx < 0 {
+                return;
+            }
+
+            if let Some(option) = self.ivars().options.get(idx as usize) {
+                unsafe { self.ivars().panel.setAllowedContentTypes(&option.types) };
+            }
+        }
+    }
+);
+
+impl SavePanelHandler {
+    fn new(
+        mtm: MainThreadMarker,
+        panel: Retained<NSSavePanel>,
+        options: Vec<FormatOption>,
+    ) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(SavePanelHandlerIvars { panel, options });
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
+fn build_format_accessory_view(
+    mtm: MainThreadMarker,
+    filters: &[Filter],
+    label_text: &str,
+) -> (Retained<NSView>, Retained<NSPopUpButton>) {
+    // NSSavePanel doesn't add its own padding around the accessory view, so the
+    // view's height needs enough slack above/below the controls (once centered)
+    // to avoid feeling cramped against the file list and the button row.
+    let view_height = 44.0;
+    let popup_width = 220.0;
+    let popup_height = 25.0;
+
+    // `labelWithString` already sizes the field to fit, but `sizeToFit` makes that
+    // explicit and lets us read back the real (font-metric-based) size below,
+    // rather than guessing a pixel width from the string's byte length.
+    let label = unsafe { NSTextField::labelWithString(&NSString::from_str(label_text), mtm) };
+    unsafe { label.sizeToFit() };
+    let label_size = label.frame().size;
+
+    let popup_x = label_size.width + 5.0;
+
+    let view = unsafe {
+        NSView::initWithFrame(
+            NSView::alloc(mtm),
+            NSRect::new(
+                NSPoint::new(0.0, 0.0),
+                NSSize::new(popup_x + popup_width, view_height),
+            ),
+        )
+    };
+    // Keeps the row centered (rather than pinned to its initial absolute position)
+    // if the user resizes the save panel, without stretching it: `ViewWidthSizable`
+    // would make NSSavePanel drop the standard margin it gives a fixed-size
+    // accessory view, jamming the row against the panel's left edge.
+    unsafe {
+        view.setAutoresizingMask(
+            NSAutoresizingMaskOptions::ViewMinXMargin | NSAutoresizingMaskOptions::ViewMaxXMargin,
+        )
+    };
+
+    unsafe {
+        label.setFrameOrigin(NSPoint::new(0.0, (view_height - label_size.height) / 2.0));
+    }
+
+    let popup = unsafe { NSPopUpButton::new(mtm) };
+    unsafe {
+        popup.setFrame(NSRect::new(
+            NSPoint::new(popup_x, (view_height - popup_height) / 2.0),
+            NSSize::new(popup_width, popup_height),
+        ))
+    };
+    for filter in filters {
+        unsafe { popup.addItemWithTitle(&NSString::from_str(&filter.name)) };
+    }
+
+    unsafe {
+        view.addSubview(&label);
+        view.addSubview(&popup);
+    }
+
+    (view, popup)
+}
+
 impl Panel {
     pub fn build_pick_file(opt: &FileDialog, mtm: MainThreadMarker) -> Self {
         let panel = unsafe { NSOpenPanel::openPanel(mtm) };
@@ -204,9 +330,39 @@ impl Panel {
     pub fn build_save_file(opt: &FileDialog, mtm: MainThreadMarker) -> Self {
         let panel = unsafe { NSSavePanel::savePanel(mtm) };
 
-        if !opt.filters.is_empty() {
-            panel.add_filters(opt);
-        }
+        let save_panel_handler = match opt.filters.as_slice() {
+            [] => None,
+            [single] => {
+                unsafe { panel.setAllowedContentTypes(&utypes_for_filter(single)) };
+                None
+            }
+            multiple => {
+                let label_text = opt.format_label.as_deref().unwrap_or("Format:");
+                let (view, popup) = build_format_accessory_view(mtm, multiple, label_text);
+
+                let options = multiple
+                    .iter()
+                    .map(|filter| FormatOption {
+                        types: utypes_for_filter(filter),
+                    })
+                    .collect();
+
+                let handler = SavePanelHandler::new(mtm, panel.clone(), options);
+
+                unsafe {
+                    popup.setTarget(Some(&handler));
+                    popup.setAction(Some(sel!(formatChanged:)));
+                }
+
+                unsafe {
+                    panel.setAllowedContentTypes(&utypes_for_filter(&multiple[0]));
+                    popup.selectItemAtIndex(0);
+                    panel.setAccessoryView(Some(&view));
+                }
+
+                Some(handler)
+            }
+        };
 
         if let Some(path) = &opt.starting_directory {
             panel.set_path(path, opt.file_name.as_deref());
@@ -228,7 +384,9 @@ impl Panel {
             panel.set_shows_hidden_files(show);
         }
 
-        Self::new(panel, opt.parent.as_ref())
+        let mut result = Self::new(panel, opt.parent.as_ref());
+        result._save_panel_handler = save_panel_handler;
+        result
     }
 
     pub fn build_pick_folder(opt: &FileDialog, mtm: MainThreadMarker) -> Self {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -48,11 +48,11 @@ impl FileDialog {
     /// The name of the filter will be displayed on supported platforms:
     ///   * Windows
     ///   * Linux
-    ///   * Mac (`save_file` only, and only when more than one filter is registered)
+    ///   * Mac (`save_file` only, when two or more filters are registered)
     ///
-    /// On platforms/scenarios that don't support filter names (Mac's `pick_file`/`pick_files`/
-    /// etc, or Mac's `save_file` with 0 or 1 filters registered), all filters are merged into
-    /// one flat allowed-types list
+    /// In every other case — other platforms, Mac's `pick_file`/`pick_files`/etc, or Mac's
+    /// `save_file` with fewer than two filters — all filters are merged into one flat
+    /// allowed-types list
     pub fn add_filter(mut self, name: impl Into<String>, extensions: &[impl ToString]) -> Self {
         self.filters.push(Filter {
             name: name.into(),
@@ -224,11 +224,11 @@ impl AsyncFileDialog {
     /// The name of the filter will be displayed on supported platforms:
     ///   * Windows
     ///   * Linux
-    ///   * Mac (`save_file` only, and only when more than one filter is registered)
+    ///   * Mac (`save_file` only, when two or more filters are registered)
     ///
-    /// On platforms/scenarios that don't support filter names (Mac's `pick_file`/`pick_files`/
-    /// etc, or Mac's `save_file` with 0 or 1 filters registered), all filters are merged into
-    /// one flat allowed-types list
+    /// In every other case — other platforms, Mac's `pick_file`/`pick_files`/etc, or Mac's
+    /// `save_file` with fewer than two filters — all filters are merged into one flat
+    /// allowed-types list
     pub fn add_filter(mut self, name: impl Into<String>, extensions: &[impl ToString]) -> Self {
         self.file_dialog = self.file_dialog.add_filter(name, extensions);
         self

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -26,6 +26,7 @@ pub struct FileDialog {
     pub(crate) parent_display: Option<RawDisplayHandle>,
     pub(crate) can_create_directories: Option<bool>,
     pub(crate) show_hidden_files: Option<bool>,
+    pub(crate) format_label: Option<String>,
 }
 
 // Oh god, I don't like sending RawWindowHandle between threads but here we go anyways...
@@ -47,8 +48,11 @@ impl FileDialog {
     /// The name of the filter will be displayed on supported platforms:
     ///   * Windows
     ///   * Linux
+    ///   * Mac (`save_file` only, and only when more than one filter is registered)
     ///
-    /// On platforms that don't support filter names, all filters will be merged into one filter
+    /// On platforms/scenarios that don't support filter names (Mac's `pick_file`/`pick_files`/
+    /// etc, or Mac's `save_file` with 0 or 1 filters registered), all filters are merged into
+    /// one flat allowed-types list
     pub fn add_filter(mut self, name: impl Into<String>, extensions: &[impl ToString]) -> Self {
         self.filters.push(Filter {
             name: name.into(),
@@ -119,6 +123,14 @@ impl FileDialog {
         self.show_hidden_files = Some(show);
         self
     }
+
+    /// Set the label shown next to the format picker in `save_file`'s accessory view
+    /// (only shown when two or more filters are registered). Defaults to "Format:".
+    /// Supported in: `macos`.
+    pub fn set_format_label(mut self, label: impl Into<String>) -> Self {
+        self.format_label = Some(label.into());
+        self
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -169,9 +181,13 @@ impl FileDialog {
     ///
     /// #### Platform specific notes regarding save dialog filters:
     /// - On macOS
-    ///     - If filter is set, all files will be grayed out (no matter the extension sadly)
-    ///     - If user does not type an extension MacOs will append first available extension from filters list
-    ///     - If user types in filename with extension MacOs will check if it exists in filters list, if not it will display appropriate message
+    ///     - If exactly one filter is set, all other file types are grayed out (no matter the extension sadly)
+    ///     - If two or more filters are registered, a dropdown accessory view (labeled "Format:" by default,
+    ///       see `set_format_label`) is shown listing each filter's name; selecting one updates which file
+    ///       types are allowed and the auto-appended extension
+    ///     - If user does not type an extension MacOs will append the first available extension from the active filter
+    ///     - If user types in filename with extension MacOs will check if it exists in the active filter's list, if
+    ///       not it will display appropriate message
     /// - On GTK
     ///     - It only filters which already existing files get shown to the user
     ///     - It does not append extensions automatically
@@ -208,8 +224,11 @@ impl AsyncFileDialog {
     /// The name of the filter will be displayed on supported platforms:
     ///   * Windows
     ///   * Linux
+    ///   * Mac (`save_file` only, and only when more than one filter is registered)
     ///
-    /// On platforms that don't support filter names, all filters will be merged into one filter
+    /// On platforms/scenarios that don't support filter names (Mac's `pick_file`/`pick_files`/
+    /// etc, or Mac's `save_file` with 0 or 1 filters registered), all filters are merged into
+    /// one flat allowed-types list
     pub fn add_filter(mut self, name: impl Into<String>, extensions: &[impl ToString]) -> Self {
         self.file_dialog = self.file_dialog.add_filter(name, extensions);
         self
@@ -273,6 +292,14 @@ impl AsyncFileDialog {
         self.file_dialog = self.file_dialog.set_show_hidden_files(show);
         self
     }
+
+    /// Set the label shown next to the format picker in `save_file`'s accessory view
+    /// (only shown when two or more filters are registered). Defaults to "Format:".
+    /// Supported in: `macos`.
+    pub fn set_format_label(mut self, label: impl Into<String>) -> Self {
+        self.file_dialog = self.file_dialog.set_format_label(label);
+        self
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -331,9 +358,13 @@ impl AsyncFileDialog {
     ///
     /// #### Platform specific notes regarding save dialog filters:
     /// - On MacOs
-    ///     - If filter is set, all files will be grayed out (no matter the extension sadly)
-    ///     - If user does not type an extension MacOs will append first available extension from filters list
-    ///     - If user types in filename with extension MacOs will check if it exists in filters list, if not it will display appropriate message
+    ///     - If exactly one filter is set, all other file types are grayed out (no matter the extension sadly)
+    ///     - If two or more filters are registered, a dropdown accessory view (labeled "Format:" by default,
+    ///       see `set_format_label`) is shown listing each filter's name; selecting one updates which file
+    ///       types are allowed and the auto-appended extension
+    ///     - If user does not type an extension MacOs will append the first available extension from the active filter
+    ///     - If user types in filename with extension MacOs will check if it exists in the active filter's list, if
+    ///       not it will display appropriate message
     /// - On GTK
     ///     - It only filters which already existing files get shown to the user
     ///     - It does not append extensions automatically


### PR DESCRIPTION
## Summary

`NSSavePanel` previously merged every filter registered via `add_filter` into one
flat, unnamed allowed-types list (via the deprecated `setAllowedFileTypes`), unlike
Windows and Linux, which already show filter names to the user. This PR adds a
"Format:" picker to the macOS save dialog, matching the native convention used by
apps like TextEdit/Safari.

- When **two or more filters** are registered, `save_file` now shows a "Format:"
  accessory view (an `NSPopUpButton`) listing each filter's name. Selecting one
  live-updates the panel's allowed content types (and the auto-appended extension)
  via the modern `allowedContentTypes` API.
- When **zero or one** filter is registered, behavior is unchanged — no picker is
  shown, since there's nothing to choose between.
- Added `FileDialog::set_format_label`/`AsyncFileDialog::set_format_label` so
  callers can customize the picker's label (defaults to `"Format:"`).
- Updated the `add_filter`/`save_file` doc comments to describe the new
  macOS behavior.

<img width="992" height="645" alt="Screenshot 2026-07-06 at 15 27 05" src="https://github.com/user-attachments/assets/e32f21cb-07ab-46fe-bf1c-f3fbe3f20181" />

## Test plan

- [x] `cargo build`/`cargo check` clean on macOS
- [x] Manually verified via `examples/save.rs` with two filters registered:
  - Format picker renders correctly, centered, with proper padding
  - Selecting a filter live-switches the allowed content type and the
    auto-appended extension (`.txt` → `.rtf`)
  - Custom label via `set_format_label` renders correctly at various lengths
  - 0-filter and 1-filter cases regression-tested — no picker shown, unchanged
    behavior
  - Existing open-picker (`pick_file`/`pick_files`) filtering unaffected