### PR TITLE
wasm: sanitize title contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `FileDialog::set_show_hidden_files` and `AsyncFileDialog::set_show_hidden_files` to control hidden file visibility. Supported on macOS, Windows, and Linux (GTK3).
 - Honor `FileDialog::set_directory` and `AsyncFileDialog::set_directory` when using the zenity fallback backend on Linux.
 - Fix `liblary` typo in docs
+- Change wasm title to sanitize text contents via `title_el.set_text_content()` rather than `title_el.set_inner_html()`.
 
 ## 0.17.2
 

--- a/src/backend/wasm.rs
+++ b/src/backend/wasm.rs
@@ -59,7 +59,7 @@ impl<'a> WasmDialog<'a> {
             let title_el: HtmlElement = document.create_element("div").unwrap().dyn_into().unwrap();
 
             title_el.set_id("rfd-title");
-            title_el.set_inner_html(title);
+            title_el.set_text_content(Some(title));
 
             card.append_child(&title_el).unwrap();
             title_el


### PR DESCRIPTION
If users of the crate set titles with any kind of untrusted input like a tag, filename, or whatever, arbitrary HTML can be inserted.

### Reproduction
Modify https://github.com/PolyMeilex/rfd/blob/master/examples/web-trunk/src/main.rs#L17 to contain:
```diff
-        let task = rfd::AsyncFileDialog::new().pick_file();
+        let task = rfd::AsyncFileDialog::new()
+            .set_title(r#"<img src=x onerror="alert('HACK THE PLANET')">"#)
+            .pick_file();
```

then run `trunk serve` and click the rfd button.